### PR TITLE
Allow opcclient to take security options

### DIFF
--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -133,8 +133,6 @@ module.exports = function (RED) {
 	    var options = {};
 	    options.securityPolicy = opcuaEndpoint.securityPolicy;
 	    options.securityMode = opcuaEndpoint.securityMode;
-	    verbose_log.log("Client connection setting - Security Policy: " + options.securityPolicy);
-	    verbose_log.log("Client connection setting - Security Mode: " + options.securityMode);
 		
             node.client = new opcua.OPCUAClient(options);
             items = [];

--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -21,9 +21,9 @@ module.exports = function (RED) {
     var opcua = require('node-opcua');
     var opcuaBasics = require('./opcua-basics');
     var nodeId = require('node-opcua/lib/datamodel/nodeid');
-	var UAProxyManager = require("node-opcua/lib/client/proxy").UAProxyManager;
-	var coerceNodeId = require("node-opcua/lib/datamodel/nodeid").coerceNodeId;
-	var makeNodeId = require("node-opcua/lib/datamodel/nodeid").makeNodeId;	
+    var UAProxyManager = require("node-opcua/lib/client/proxy").UAProxyManager;
+    var coerceNodeId = require("node-opcua/lib/datamodel/nodeid").coerceNodeId;
+    var makeNodeId = require("node-opcua/lib/datamodel/nodeid").makeNodeId;	
     var browse_service = require("node-opcua/lib/services/browse_service");
     var async = require("async");
     var treeify = require('treeify');
@@ -129,7 +129,14 @@ module.exports = function (RED) {
 
             node.client = null;
             verbose_warn("create Client ...");
-            node.client = new opcua.OPCUAClient();
+		
+	    var options = {};
+	    options.securityPolicy = opcuaEndpoint.securityPolicy;
+	    options.securityMode = opcuaEndpoint.securityMode;
+	    verbose_log.log("Client connection setting - Security Policy: " + options.securityPolicy);
+	    verbose_log.log("Client connection setting - Security Mode: " + options.securityMode);
+		
+            node.client = new opcua.OPCUAClient(options);
             items = [];
             node.items = items;
             set_node_status_to("create client");

--- a/opcua/105-opcuaendpoint.html
+++ b/opcua/105-opcuaendpoint.html
@@ -21,6 +21,8 @@ limitations under the License.
         category: 'config',
         defaults: {
             endpoint: {value: "", required: true},
+            secpolicy: {value: "None", required: true},
+            secmode: {value: "NONE", required: true},
             login: {value: false}
         },
         credentials: {
@@ -71,13 +73,21 @@ limitations under the License.
         <input type="text" id="node-config-input-endpoint">
     </div>
     <div class="form-row">
-        <label for="node-config-input-sign"><i class="icon-key"></i> Sign</label>
-        <select type="text" id="node-input-sign">
+        <label for="node-config-input-secpolicy"><i class="icon-key"></i> SecurityPolicy</label>
+        <select type="text" id="node-config-input-secpolicy">
             <option value="None">None</option>
-            <option value="Basic128Rsa15Signed">Basic128Rsa15 signed</option>
-            <option value="Basic256Signed">Basic256 signed</option>
-            <option value="Basic128Rsa15">Basic128Rsa15 signed+crypted</option>
-            <option value="Basic256Signed">Basic256 signed+crypted</option>
+            <option value="Basic128">Basic128</option>
+            <option value="Basic128Rsa15">Basic128Rsa15</option>
+            <option value="Basic256">Basic256</option>
+            <option value="Basic256Rsa15">Basic256Rsa15</option>
+        </select>
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-secmode"><i class="icon-key"></i> SecurityMode</label>
+        <select type="text" id="node-config-input-secmode">
+            <option value="NONE">None</option>
+            <option value="SIGN">Sign</option>
+            <option value="SIGNANDENCRYPT">Sign&Encrypt</option>
         </select>
     </div>
     <div class="form-row">

--- a/opcua/105-opcuaendpoint.js
+++ b/opcua/105-opcuaendpoint.js
@@ -24,12 +24,20 @@ module.exports = function (RED) {
         RED.nodes.createNode(this, n);
 
         this.endpoint = n.endpoint;
+        this.secpolicy = n.secpolicy;
+        this.secmode = n.secmode;
         this.login = n.login;
 
         if (this.credentials) {
             this.user = this.credentials.user;
             this.password = this.credentials.password;
         }
+		
+        this.securityPolicy = opcua.SecurityPolicy[this.sign];
+        if ( this.securityPolicy == undefined ) this.securityPolicy = opcua.SecurityPolicy.None;
+
+        this.securityMode = opcua.MessageSecurityMode[this.msgsec];
+        if ( this.securityMode == undefined ) this.securityMode = opcua.MessageSecurityMode.NONE;
     }
 
     RED.nodes.registerType("OpcUa-Endpoint", OpcUaEndpointNode, {

--- a/opcua/105-opcuaendpoint.js
+++ b/opcua/105-opcuaendpoint.js
@@ -24,20 +24,14 @@ module.exports = function (RED) {
         RED.nodes.createNode(this, n);
 
         this.endpoint = n.endpoint;
-        this.secpolicy = n.secpolicy;
-        this.secmode = n.secmode;
+        this.securityPolicy = opcua.SecurityPolicy[n.secpolicy] || opcua.SecurityPolicy.None;
+        this.securityMode = opcua.MessageSecurityMode[n.secmode] || opcua.MessageSecurityMode.NONE;
         this.login = n.login;
 
         if (this.credentials) {
             this.user = this.credentials.user;
             this.password = this.credentials.password;
         }
-		
-        this.securityPolicy = opcua.SecurityPolicy[this.sign];
-        if ( this.securityPolicy == undefined ) this.securityPolicy = opcua.SecurityPolicy.None;
-
-        this.securityMode = opcua.MessageSecurityMode[this.msgsec];
-        if ( this.securityMode == undefined ) this.securityMode = opcua.MessageSecurityMode.NONE;
     }
 
     RED.nodes.registerType("OpcUa-Endpoint", OpcUaEndpointNode, {


### PR DESCRIPTION
Possibility to select security options in node-red editor and use them as additional options for opc client creation (see [node-opcua:perform_simple_connection](https://github.com/node-opcua/node-opcua/blob/c060e78b90e1ea139ec05373ec816891403b97ad/test/secure_connection/test_e2e_secure_UserNameIdentityToken.js#L80))