### PR TITLE
Removed old Basic128 Security Policy

### DIFF
--- a/opcua/105-opcuaendpoint.html
+++ b/opcua/105-opcuaendpoint.html
@@ -74,7 +74,6 @@ limitations under the License.
         <label for="node-config-input-secpol"><i class="icon-key"></i> SecurityPolicy</label>
         <select type="text" id="node-config-input-secpol">
             <option value="None">None</option>
-            <option value="Basic128">Basic128</option>
             <option value="Basic128Rsa15">Basic128Rsa15</option>
             <option value="Basic256">Basic256</option>
             <option value="Basic256Sha256">Basic256Sha256</option>


### PR DESCRIPTION
Basic128Rsa15 is still allowed (even if has been deprecated as well as Basic256)
Basic128 shall not be used anymore.
Source is OPC UA 1.04 Specification Part 7 Profiles.