### PR TITLE
Support for writing multiple values with one call.

### DIFF
--- a/opcua/102-opcuaclient.html
+++ b/opcua/102-opcuaclient.html
@@ -93,6 +93,7 @@ limitations under the License.
             <option value="info">INFO</option>
             <option value="monitor">MONITOR</option>
             <option value="readmultiple">READ MULTIPLE</option>
+            <option value="writemultiple">WRITE MULTIPLE</option>
         </select>
     </div>
     <div class="form-row" id="node-input-timerow">


### PR DESCRIPTION
Added support for writing multiple values (same or different nodeIds) in one call (for performance).
The message format is as follow:

- _msg.topic_: default nodeId (if not specified en payload elements). [required]
- _msg.datatype_: default datatype of the values (if not specified en payload elements).
- _msg.timestamp_: default timestamp for the values.
- _msg.payload_: array of values to write.
- _msg.payload[].value_: value to write. [required]
- _msg.payload[].nodeId_: nodeId of the variable, if not specified the nodeId in _msg.topic_ will be used.
- _msg.payload[].datatype_: datatype of the variable, if not specified the datatype in _msg.datatype_ will be used.
- _msg.payload[].timestamp_: timestamp of the value, if not specified the timestamp in _msg.timestamp_ or current time will be used.
