### PR TITLE
Fix casing of "selfSigned" to match what's in the opcua-client package

### DIFF
--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -86,7 +86,7 @@ module.exports = function (RED) {
     if (!clientPkg)
       verbose_warn("Cannot find node-opcua-client package with client certificate");
     // Client certificate from node-opcua-client\certificates, created by node-opcua installation
-    connectionOption.certificateFile = path.join(clientPkg, "/certificates/client_selfSigned_cert_2048.pem"),
+    connectionOption.certificateFile = path.join(clientPkg, "/certificates/client_selfsigned_cert_2048.pem"),
     connectionOption.privateKeyFile =  path.join(clientPkg, "/certificates/PKI/own/private/private_key.pem")
     verbose_log("Using client certificate " + connectionOption.certificateFile);
 


### PR DESCRIPTION
Fixes #156

This PR corrects the casing of the default certificate name to match what's present in the node-opcua-client npm package.  This allows for the client node to be used on operating systems with case sensitive file systems (e.g. linux).

