### PR TITLE
Fix for OpcUA Client node message without payload

### DIFF
--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -436,7 +436,7 @@ module.exports = function (RED) {
         node.action = msg.action;
       }
       // With new node-red easier to set action into payload
-      if (msg.payload.action) {
+      if (msg.payload && msg.payload.action) {
         verbose_log("Override node action by msg.payload.action:" + msg.payload.action);
         node.action = msg.payload.action;
       }


### PR DESCRIPTION
There was a small bug when you didn't have a payload (or it was null) on the message you send to OpcUA Client node, for example to start monitoring a new tag. The nodeId must be specified as the topic, so you could have situations where you don't have any payload set, just the topic.