### PR TITLE
Adding Certificate Manager on OPC Server node

### DIFF
--- a/opcua/104-opcuaserver.html
+++ b/opcua/104-opcuaserver.html
@@ -23,7 +23,8 @@ limitations under the License.
         defaults: {
             port: {value: "53880", required: true},
             name: {value:""},
-            endpoint: {value: ""}
+            endpoint: {value: ""},
+            autoAcceptUnknownCertificate: {value: true}
         },
         inputs:1,
         outputs:1,
@@ -50,13 +51,15 @@ limitations under the License.
         <label for="node-input-name"><i class="icon-tasks"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="">
     </div>
-        <div class="form-row">
+    <div class="form-row">
         <label for="node-input-endpoint"><i class="icon-tasks"></i> Endpoint</label>
         <input type="text" id="node-input-endpoint" placeholder="UA/SimpleNodeRedServer">
     </div>
+    <div class="form-row">
+        <label for="node-input-autoAcceptUnknownCertificate"><i class="icon-tasks"></i> Auto Accept Unknown Certificates</label>
+        <input type="checkbox" id="node-input-autoAcceptUnknownCertificate">
+    </div>
 </script>
-
-
 
 <script type="text/x-red" data-help-name="OpcUa-Server">
     <p>Creates OPC UA server with own variables, object structures and methods to endpoint: opc.tcp://hostname.local:53880/</p>

--- a/opcua/104-opcuaserver.js
+++ b/opcua/104-opcuaserver.js
@@ -31,6 +31,7 @@ module.exports = function (RED) {
         this.name = n.name;
         this.port = n.port;
         this.endpoint = n.endpoint;
+        this.autoAcceptUnknownCertificate = n.autoAcceptUnknownCertificate;
 
         var node = this;
         var variables = {
@@ -92,10 +93,15 @@ module.exports = function (RED) {
             if (!serverPkg)
                 verbose_warn("Cannot find node-opcua-server package with server certificate");
 
+            var rootpki = path.join(serverPkg, "/certificates/PKI");
             var certFile = path.join(serverPkg, "/certificates/server_selfsigned_cert_2048.pem");
             var privFile = path.join(serverPkg, "/certificates/PKI/own/private/private_key.pem");
             verbose_log("Using server certificate " + certFile);
             var server_options = {
+                serverCertificateManager: new opcua.OPCUACertificateManager({
+                    automaticallyAcceptUnknownCertificate: node.autoAcceptUnknownCertificate,
+                    rootFolder: rootpki,
+                }),
                 certificateFile: certFile,
                 privateKeyFile: privFile,
                 port: parseInt(n.port),


### PR DESCRIPTION
This PR add the certificate manager feature to the OPC Server node. This allow the server to choose the policy of auto accept unknown client certificates. Adding this because we need to only some specific clients have access to our OPC Server.