### PR TITLE
Prevents an error that occurs when the error is a connection error

### DIFF
--- a/opcua/107-opcuamethod.js
+++ b/opcua/107-opcuamethod.js
@@ -158,7 +158,7 @@ module.exports = function (RED) {
           node.status({
               fill: "red",
               shape: "dot",
-              text: "Error Items: " + node.items.length
+              text: "Error Items: " + node.items ? node.items.length : '-'
           });
       }
       node.log("Waiting method calls...");


### PR DESCRIPTION
Prevents an error that occurs when the error is a connection error, and node.items does not exist