### PR TITLE
Adding support for multiple custom nodeset files.

### DIFF
--- a/opcua/104-opcuaserver.html
+++ b/opcua/104-opcuaserver.html
@@ -25,7 +25,7 @@ limitations under the License.
             name: {value:""},
             endpoint: {value: ""},
             users: {value: "users.json"},
-            nodeset: {value: ""},
+            nodesetDir: {value: ""},
             autoAcceptUnknownCertificate: {value: true},
             registerToDiscovery: {value: false},
             constructDefaultAddressSpace: {value: true},
@@ -83,8 +83,8 @@ limitations under the License.
         <input type="text" id="node-input-users" placeholder="users.json">
     </div>
     <div class="form-row">
-        <label for="node-input-nodeset"><i class="icon-tasks"></i> Custom nodeset file</label>
-        <input type="text" id="node-input-nodeset" placeholder="">
+        <label for="node-input-nodesetDir"><i class="icon-tasks"></i> Custom nodeset directory</label>
+        <input type="text" id="node-input-nodesetDir" placeholder="">
     </div>
     <div class="form-row">
         <label for="node-input-autoAcceptUnknownCertificate" style="width:72%;"><i class="icon-tasks"></i> Auto Accept Unknown Certificates</label>

--- a/opcua/104-opcuaserver.js
+++ b/opcua/104-opcuaserver.js
@@ -181,9 +181,13 @@ module.exports = function (RED) {
                         path.join(__dirname, 'public/vendor/opc-foundation/xml/Opc.Ua.AutoID.NodeSet2.xml'), // Support for RFID Readers
                         path.join(__dirname, 'public/vendor/opc-foundation/xml/Opc.ISA95.NodeSet2.xml')   // ISA95
         ];
-        // Add custom nodeset (xml-file) for server
-        if (node.nodeset && fs.existsSync(node.nodeset)) {
-            xmlFiles[3] = node.nodeset;
+        // Add custom nodesets (xml-files) for server
+        if (node.nodesetDir && fs.existsSync(node.nodesetDir)) {
+            fs.readdirSync(node.nodesetDir).forEach(fileName => {
+                if (path.extname(fileName).toLowerCase() === '.xml') {
+                    xmlFiles.push(path.join(node.nodesetDir, fileName));
+                };
+            });
         }
         verbose_warn("node set:" + xmlFiles.toString());
         

--- a/opcua/104-opcuaserver.js
+++ b/opcua/104-opcuaserver.js
@@ -37,7 +37,7 @@ module.exports = function (RED) {
         this.port = n.port;
         this.endpoint = n.endpoint;
         this.users = n.users;
-        this.nodeset = n.nodeset;
+        this.nodesetDir = n.nodesetDir;
         this.autoAcceptUnknownCertificate = n.autoAcceptUnknownCertificate;
         this.allowAnonymous = n.allowAnonymous;
         this.endpointNone = n.endpointNone;
@@ -181,6 +181,7 @@ module.exports = function (RED) {
                         path.join(__dirname, 'public/vendor/opc-foundation/xml/Opc.Ua.AutoID.NodeSet2.xml'), // Support for RFID Readers
                         path.join(__dirname, 'public/vendor/opc-foundation/xml/Opc.ISA95.NodeSet2.xml')   // ISA95
         ];
+        
         // Add custom nodesets (xml-files) for server
         if (node.nodesetDir && fs.existsSync(node.nodesetDir)) {
             fs.readdirSync(node.nodesetDir).forEach(fileName => {


### PR DESCRIPTION
This PR expands on the custom nodeset feature by allowing users to specify a directory from which to load multiple custom nodeset files. Only XML nodeset files in the top level directory are included.