### PR TITLE
Adding getNamespaces OPC UA server command.

### DIFF
--- a/opcua/104-opcuaserver.html
+++ b/opcua/104-opcuaserver.html
@@ -199,6 +199,7 @@ limitations under the License.
             <li><b>deleteNode</b>         msg.payload = "ns=1;s=VariableName"</li>
             <li><b>registerNamespace</b>  msg.topic = "www.acme.com" output msg.payload = ns=index </li>
             <li><b>getNamespaceIndex</b>  msg.topic = "www.acme.com" output msg.payload = ns=index </li>
+            <li><b>getNamespaces</b>      output msg.payload = { nsuri1: 1, nsuri2: 2, ... }</li>
             <li><b>setUsers</b>           msg.topic = "" msg.users JSON structure of users (username, password role)</li>
         </ul>
 

--- a/opcua/104-opcuaserver.js
+++ b/opcua/104-opcuaserver.js
@@ -863,6 +863,10 @@ module.exports = function (RED) {
                     returnValue = "ns=" + addressSpace.getNamespaceIndex(msg.topic);
                     break;
 
+                case "getNamespaces":
+                    returnValue = addressSpace.getNamespaceArray().reduce((dict, namespace, index) => (dict[namespace.namespaceUri] = index, dict), {});
+                    break;
+
                 case "setUsers":
                     if (msg.payload.hasOwnProperty("users")) {
                         users = msg.payload.users;


### PR DESCRIPTION
This PR adds the getNamespaces OPC UA server command which allows users to fetch all namespaces and their respective namespace indexes in one call rather than multiple getNamespaceIndex calls.

e.g. msg.payload=
```json
{
    "http://opcfoundation.org/UA/": 0,
    "http://opcfoundation.org/UA/AutoID/": 1,
    "http://opcfoundation.org/UA/DI/": 2,
    "http://www.OPCFoundation.org/UA/2013/01/ISA95": 3
}
```

This makes it easier to store the namespace indexes in a context to lookup namespace uris and indexes.