### PR TITLE
Server bug wrong variable accessing

### DIFF
--- a/opcua/104-opcuaserver.html
+++ b/opcua/104-opcuaserver.html
@@ -219,7 +219,7 @@ limitations under the License.
     <p>
         OPC UA message type to set variable Counter by JSON Inject
         <pre>
-        { payload : { "messageType" : "Variable",  "variableName": "Counter",  "variableValue": msg.payload }};
+        { payload : { "messageType" : "Variable", "namespace" : "1", "variableName": "Counter",  "variableValue": msg.payload }};
         </pre>
     </p>
     <p>

--- a/opcua/104-opcuaserver.js
+++ b/opcua/104-opcuaserver.js
@@ -661,32 +661,32 @@ module.exports = function (RED) {
                             nsindex = parseInt(msg.topic.substring(3));
                             namespace = allNamespaces[nsindex];
                         }
-
+                        var ns = nsindex.toString();
                         var dimensions = valueRank <= 0 ? null : [dim1]; // Fix for conformance check TODO dim2, dim3
                         var browseName = name.substring(7);
-                        variables[nsindex + ":" + browseName] = 0;
+                        variables[ns + ":" + browseName] = 0;
                         if (valueRank == 1) {
                             arrayType = opcua.VariantArrayType.Array;
                             dimensions = [dim1];
-                            variables[nsindex + ":" + browseName] = new Float32Array(dim1); // [];
+                            variables[ns + ":" + browseName] = new Float32Array(dim1); // [];
                             for (var i=0; i<dim1; i++) {
-                                variables[nsindex + ":" + browseName][i] = 0;
+                                variables[ns + ":" + browseName][i] = 0;
                             }
                         }
                         if (valueRank == 2) {
                             arrayType = opcua.VariantArrayType.Matrix;
                             dimensions = [dim1, dim2];
-                            variables[nsindex + ":" + browseName] = new Float32Array(dim1*dim2); // [];
+                            variables[ns + ":" + browseName] = new Float32Array(dim1*dim2); // [];
                             for (var i=0; i<dim1*dim2; i++) {
-                                variables[nsindex + ":" + browseName][i] = 0;
+                                variables[ns + ":" + browseName][i] = 0;
                             }
                         }
                         if (valueRank == 3) {
                             arrayType = opcua.VariantArrayType.Matrix; // Actually no Cube => Matrix with 3 dims
                             dimensions = [dim1, dim2, dim3];
-                            variables[nsindex + ":" + browseName] = new Float32Array(dim1*dim2*dim3); // [];
+                            variables[ns + ":" + browseName] = new Float32Array(dim1*dim2*dim3); // [];
                             for (var i=0; i<dim1*dim2*dim3; i++) {
-                                variables[nsindex + ":" + browseName][i] = 0;
+                                variables[ns + ":" + browseName][i] = 0;
                             }
                         }
 
@@ -716,23 +716,23 @@ module.exports = function (RED) {
                         }
                         if (datatype == "DateTime") {
                             opcuaDataType = opcua.DataType.DateTime;
-                            variables[nsindex + ":" + browseName] = new Date();
+                            variables[ns + ":" + browseName] = new Date();
                         }
                         if (datatype == "ExtensionObject") {
                             opcuaDataType = opcua.DataType.ExtensionObject;
-                            variables[nsindex + ":" + browseName] = {};
+                            variables[ns + ":" + browseName] = {};
                         }
                         if (datatype == "ByteString") {
                             opcuaDataType = opcua.DataType.ByteString;
-                            variables[nsindex + ":" + browseName] = Buffer.from("");
+                            variables[ns + ":" + browseName] = Buffer.from("");
                         }
                         if (datatype == "String") {
                             opcuaDataType = opcua.DataType.String;
-                            variables[nsindex + ":" + browseName] = "";
+                            variables[ns + ":" + browseName] = "";
                         }
                         if (datatype == "Boolean") {
                             opcuaDataType = opcua.DataType.Boolean;
-                            variables[nsindex + ":" + browseName] = true;
+                            variables[ns + ":" + browseName] = true;
                         }
                         verbose_log("Datatype: " + datatype);
                         verbose_log("OPC UA type id: "+ opcuaDataType.toString() + " dims[" + dim1 + "," + dim2 +"," + dim3 +"] == " + dimensions);
@@ -740,8 +740,8 @@ module.exports = function (RED) {
                         var init = msg.topic.indexOf("value=");
                         if (init > 0) {
                             var initialValue = msg.topic.substring(init+6);
-                            verbose_log("BrowseName: " + nsindex + ":" + browseName + " initial value: " + initialValue);
-                            variables[nsindex + ":" + browseName] = opcuaBasics.build_new_value_by_datatype(datatype, initialValue);
+                            verbose_log("BrowseName: " + ns + ":" + browseName + " initial value: " + initialValue);
+                            variables[ns + ":" + browseName] = opcuaBasics.build_new_value_by_datatype(datatype, initialValue);
                         }
 
                         
@@ -779,19 +779,19 @@ module.exports = function (RED) {
                                             arrayType,
                                             dimensions,
                                             dataType: opcuaDataType,
-                                            value: variables[nsindex + ":" + browseName]
+                                            value: variables[ns + ":" + browseName]
                                         });
                                     }
                                     else {
                                         return new opcua.Variant({
                                             arrayType,
                                             dataType: opcuaDataType,
-                                            value: variables[nsindex + ":" + browseName]
+                                            value: variables[ns + ":" + browseName]
                                         });
                                     } 
                                 },
                                 set: function (variant) {
-                                    verbose_log("Server set new variable value : " + variables[nsindex + ":" + browseName] + " browseName: " + nsindex + ":" + browseName + " new:" + stringify(variant));
+                                    verbose_log("Server set new variable value : " + variables[ns + ":" + browseName] + " browseName: " + ns + ":" + browseName + " new:" + stringify(variant));
                                     /*
                                     // TODO Array partial write need some more studies
                                     if (msg.payload.range) {
@@ -808,18 +808,18 @@ module.exports = function (RED) {
                                     }
                                     else {
                                         */
-                                        variables[nsindex + ":" + browseName] = opcuaBasics.build_new_value_by_datatype(variant.dataType.toString(), variant.value);
+                                        variables[ns + ":" + browseName] = opcuaBasics.build_new_value_by_datatype(variant.dataType.toString(), variant.value);
                                     // }
                                     // variables[browseName] = Object.assign(variables[browseName], opcuaBasics.build_new_value_by_datatype(variant.dataType.toString(), variant.value));
-                                    verbose_log("Server variable: " + variables[nsindex + ":" + browseName] + " browseName: " + nsindex + ":" + browseName);
-                                    var SetMsg = { "payload" : { "messageType" : "Variable", "variableName": nsindex + ":" + browseName, "variableValue": variables[nsindex + ":" + browseName] }};
+                                    verbose_log("Server variable: " + variables[ns + ":" + browseName] + " browseName: " + ns + ":" + browseName);
+                                    var SetMsg = { "payload" : { "messageType" : "Variable", "variableName": ns + ":" + browseName, "variableValue": variables[ns + ":" + browseName] }};
                                     verbose_log("msg Payload:" + JSON.stringify(SetMsg));
                                     node.send(SetMsg);
                                     return opcua.StatusCodes.Good;
                                 }
                             }
                         });
-                        var newvar = { "payload" : { "messageType" : "Variable", "variableName": nsindex + ":" + browseName, "nodeId": newVAR.nodeId.toString() }};
+                        var newvar = { "payload" : { "messageType" : "Variable", "variableName": ns + ":" + browseName, "nodeId": newVAR.nodeId.toString() }};
                         node.send(newvar);
 
                     }

--- a/opcua/104-opcuaserver.js
+++ b/opcua/104-opcuaserver.js
@@ -516,7 +516,8 @@ module.exports = function (RED) {
         function read_message(payload) {
             switch (payload.messageType) {
                 case 'Variable':
-                    variables[payload.variableName] = payload.variableValue;
+                    var ns = payload.namespace.toString();
+                    variables[ns + ":" + payload.variableName] = payload.variableValue;
                     break;
                 default:
                     break;
@@ -661,6 +662,7 @@ module.exports = function (RED) {
                             nsindex = parseInt(msg.topic.substring(3));
                             namespace = allNamespaces[nsindex];
                         }
+
                         var ns = nsindex.toString();
                         var dimensions = valueRank <= 0 ? null : [dim1]; // Fix for conformance check TODO dim2, dim3
                         var browseName = name.substring(7);


### PR DESCRIPTION
Dear Mika,
many thanks for this great node collection. We work a lot with your nodes. The last time I focused on the server side. I found a bug which is present since version 0.2.223. It is about wrong accessing the "variable" object due to missed conversion. nsindex is of type Integer and can not be concatenated. 

![image](https://user-images.githubusercontent.com/67979613/144411179-b1e66617-f17a-40e5-b2be-a2854d912b78.png)

The image shows the fix:
![image](https://user-images.githubusercontent.com/67979613/144412254-d0c7a6ff-bacf-49c9-9136-dc911c6370e4.png)

It is indeed a great idea to combine the browseName with the namespace index but we need also to transfer this to the read_message function. 

![image](https://user-images.githubusercontent.com/67979613/144411949-573cd01e-c6b1-410a-b3b3-f05ba5ceb729.png)

For this I adjusted the documentation: a new property "namespace" is required to change a server variable.
![image](https://user-images.githubusercontent.com/67979613/144412581-368c61c1-7248-4a4f-8c43-b6fedb0153e6.png)


Feel free to apply this code to your great project.

regards,
Chris

