### PR TITLE
Add server path and give each server its own cert manager

### DIFF
--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -40,7 +40,7 @@ module.exports = function (RED) {
   var TimestampsToReturn = read_service.TimestampsToReturn;
   var subscription_service = require("node-opcua-service-subscription");
 
-  const { createCertificateManager } = require("./utils");
+  const { createClientCertificateManager } = require("./utils");
   const { dumpCertificates } = require("./dump_certificates");
 
   const {parse, stringify} = require('flatted');
@@ -75,7 +75,7 @@ module.exports = function (RED) {
     if (node.folderName4PKI && node.folderName4PKI.length>0) {
       verbose_log("Node: " + node.name + " using own PKI folder:" + node.folderName4PKI);
     }
-    connectionOption.clientCertificateManager = createCertificateManager(true, node.folderName4PKI); // AutoAccept certificates, TODO add to client node as parameter if really needed
+    connectionOption.clientCertificateManager = createClientCertificateManager(true, node.folderName4PKI); // AutoAccept certificates, TODO add to client node as parameter if really needed
 
     if (node.certificate === "l" && node.localfile) {
       verbose_log("Using 'own' local certificate file " + node.localfile);

--- a/opcua/104-opcuaserver.html
+++ b/opcua/104-opcuaserver.html
@@ -26,6 +26,7 @@ limitations under the License.
             endpoint: {value: ""},
             users: {value: "users.json"},
             nodesetDir: {value: ""},
+            folderName4PKI: {value: ""},
             autoAcceptUnknownCertificate: {value: true},
             registerToDiscovery: {value: false},
             constructDefaultAddressSpace: {value: true},
@@ -85,6 +86,10 @@ limitations under the License.
     <div class="form-row">
         <label for="node-input-nodesetDir"><i class="icon-tasks"></i> Custom nodeset directory</label>
         <input type="text" id="node-input-nodesetDir" placeholder="">
+    </div>
+    <div class="form-row">
+        <label for="node-input-folderName4PKI"><i class="icon-tasks"></i> PKI certificate folder</label>
+        <input type="text" id="node-input-folderName4PKI" placeholder="">
     </div>
     <div class="form-row">
         <label for="node-input-autoAcceptUnknownCertificate" style="width:72%;"><i class="icon-tasks"></i> Auto Accept Unknown Certificates</label>

--- a/opcua/104-opcuaserver.js
+++ b/opcua/104-opcuaserver.js
@@ -29,7 +29,7 @@ module.exports = function (RED) {
     var chalk = require("chalk");
     var opcuaBasics = require('./opcua-basics');
     const {parse, stringify} = require('flatted');
-    const { createCertificateManager, createUserCertificateManager } = require("./utils");
+    const { createServerCertificateManager, createUserCertificateManager } = require("./utils");
     const { ExtensionObject } = require("node-opcua-extension-object");
     function OpcUaServerNode(n) {
 
@@ -40,6 +40,7 @@ module.exports = function (RED) {
         this.endpoint = n.endpoint;
         this.users = n.users;
         this.nodesetDir = n.nodesetDir;
+        this.folderName4PKI = n.folderName4PKI; // Storage folder for PKI and certificates
         this.autoAcceptUnknownCertificate = n.autoAcceptUnknownCertificate;
         this.allowAnonymous = n.allowAnonymous;
         this.endpointNone = n.endpointNone;
@@ -202,8 +203,8 @@ module.exports = function (RED) {
             verbose_warn("create Server from XML ...");
             // DO NOT USE "%FQDN%" anymore, hostname is OK
             const applicationUri =  opcua.makeApplicationUrn(os.hostname(), "node-red-contrib-opcua-server");
-            const serverCertificateManager = createCertificateManager(node.autoAcceptUnknownCertificate, "");
-            const userCertificateManager = createUserCertificateManager(node.autoAcceptUnknownCertificate, "");
+            const serverCertificateManager = createServerCertificateManager(node.autoAcceptUnknownCertificate, node.folderName4PKI);
+            const userCertificateManager = createUserCertificateManager(node.autoAcceptUnknownCertificate, node.folderName4PKI);
 
 
             var registerMethod = null;

--- a/opcua/utils.js
+++ b/opcua/utils.js
@@ -5,8 +5,17 @@ const envPaths = require("env-paths");
 const config = envPaths("node-red-opcua").config;
 
 
-let _g_certificateManager = null;
-function createCertificateManager(autoAccept, folderName) {
+let _g_clientCertificateManager = null;
+
+function createClientCertificateManager(autoAccept, folderName) {
+    return createCertificateManager(false, autoAccept, folderName);
+}
+
+function createServerCertificateManager(autoAccept, folderName) {
+    return createCertificateManager(true, autoAccept, folderName);
+}
+
+function createCertificateManager(isServer, autoAccept, folderName) {
     if (folderName && folderName.length > 0) {
         if (path.isAbsolute(folderName)) {
             folder = folderName;
@@ -22,17 +31,24 @@ function createCertificateManager(autoAccept, folderName) {
     }
     else {
         folder = config;
-        if (_g_certificateManager) {
-            return _g_certificateManager;
+        if (isServer) {
+            return new opcua.OPCUACertificateManager({
+                name: "PKI",
+                rootFolder: path.join(folder, "PKI"),
+                automaticallyAcceptUnknownCertificate: autoAccept
+            });
+        } else if (_g_clientCertificateManager){
+            return _g_clientCertificateManager;
+        } else {
+            return _g_clientCertificateManager = new opcua.OPCUACertificateManager({
+                name: "PKI",
+                rootFolder: path.join(folder, "PKI"),
+                automaticallyAcceptUnknownCertificate: autoAccept
+            });
         }
     }
-
-    return _g_certificateManager = new opcua.OPCUACertificateManager({
-        name: "PKI",
-        rootFolder: path.join(folder, "PKI"),
-        automaticallyAcceptUnknownCertificate: autoAccept
-    });
 }
+
 let _g_userCertificateManager = null;
 function createUserCertificateManager(autoAccept, folderName) {
      if (folderName && folderName.length > 0) {
@@ -60,5 +76,6 @@ function createUserCertificateManager(autoAccept, folderName) {
     });
 }
 
-exports.createCertificateManager = createCertificateManager;
+exports.createClientCertificateManager = createClientCertificateManager;
+exports.createServerCertificateManager = createServerCertificateManager;
 exports.createUserCertificateManager = createUserCertificateManager;


### PR DESCRIPTION
Addressing comments in [this thread](https://github.com/mikakaraila/node-red-contrib-opcua/issues/372).

Changes are:
- Unique certificate manager per server (so the `autoAccept` setting is not overriden by the global default if global is created by client)
- Option for custom PKI path for server (as well as client)