### PR TITLE
BUG FIX : browse name error in case of ns>9 in AddVariable and AddFolder

### DIFF
--- a/opcua/104-opcuaserver.js
+++ b/opcua/104-opcuaserver.js
@@ -599,7 +599,7 @@ module.exports = function (RED) {
                         folder = ns.addObject({
                             organizedBy: addressSpace.findNode(parentFolder.nodeId),
                             nodeId: msg.topic,
-                            browseName: msg.topic.substring(7)
+                            browseName: msg.topic.substring(msg.topic.indexOf(";s=")+3)
                         })
                     }
                     break;
@@ -671,7 +671,7 @@ module.exports = function (RED) {
 
                         var ns = nsindex.toString();
                         var dimensions = valueRank <= 0 ? null : [dim1]; // Fix for conformance check TODO dim2, dim3
-                        var browseName = name.substring(7);
+                        var browseName = name.substring(name.indexOf(";s=")+3);
                         variables[ns + ":" + browseName] = 0;
                         if (valueRank == 1) {
                             arrayType = opcua.VariantArrayType.Array;


### PR DESCRIPTION
BUG
If `ns` is composed of more than one character then the `browseName` is not correctly extracted since it uses a fixed substring(7)
FIX
Assign `browseName` by indexing ";s=" before the extraction