### PR TITLE
Add OPCUA Browser endpointBrowse

### DIFF
--- a/examples/OPCUA Browser endpointBrowse example.json
+++ b/examples/OPCUA Browser endpointBrowse example.json
@@ -1,0 +1,101 @@
+[
+    {
+        "id": "58c0065ebdc1d89d",
+        "type": "tab",
+        "label": "OPC UA Browser endpointBrowse example",
+        "disabled": true,
+        "info": "",
+        "env": []
+    },
+    {
+        "id": "956a4221da6bda1f",
+        "type": "function",
+        "z": "58c0065ebdc1d89d",
+        "name": "browse with specific endpoint",
+        "func": "msg.payload={\"actiontype\":\"endpointBrowse\"};\nmsg.OpcUaEndpoint = {\n    credentials: {},\n    endpoint: msg.endpoint,\n    securityPolicy: 'None',\n    securityMode: 'None',\n    login: false,\n    user: undefined,\n    password: undefined \n}\n\nreturn msg;",
+        "outputs": 1,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 460,
+        "y": 200,
+        "wires": [
+            [
+                "6b17b2da2b942bb4"
+            ]
+        ]
+    },
+    {
+        "id": "3bcd718c7e713c9d",
+        "type": "inject",
+        "z": "58c0065ebdc1d89d",
+        "name": "endpointBrowse",
+        "props": [
+            {
+                "p": "endpoint",
+                "v": "opc.tcp://192.168.137.1:53530/OPCUA/SimulationServer",
+                "vt": "str"
+            },
+            {
+                "p": "topic",
+                "vt": "str"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": "0",
+        "topic": "ns=3;s=85/0:Simulation",
+        "x": 200,
+        "y": 200,
+        "wires": [
+            [
+                "956a4221da6bda1f"
+            ]
+        ]
+    },
+    {
+        "id": "869acefead40215e",
+        "type": "debug",
+        "z": "58c0065ebdc1d89d",
+        "name": "",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 890,
+        "y": 200,
+        "wires": []
+    },
+    {
+        "id": "6b17b2da2b942bb4",
+        "type": "OpcUa-Browser",
+        "z": "58c0065ebdc1d89d",
+        "endpoint": "83439742.083188",
+        "item": "",
+        "datatype": "",
+        "topic": "",
+        "items": [],
+        "name": "",
+        "x": 690,
+        "y": 200,
+        "wires": [
+            [
+                "869acefead40215e"
+            ]
+        ]
+    },
+    {
+        "id": "83439742.083188",
+        "type": "OpcUa-Endpoint",
+        "endpoint": "opc.tcp://0.0.0.0:4840/",
+        "secpol": "None",
+        "secmode": "None",
+        "login": false
+    }
+]

--- a/opcua/103-opcuabrowser.js
+++ b/opcua/103-opcuabrowser.js
@@ -171,7 +171,13 @@ module.exports = function (RED) {
                             }
                         }
                         break;
-
+                    case 'endpointBrowse':
+                        node.warn("endpointBrowse");
+                        if (msg.hasOwnProperty('OpcUaEndpoint')) {
+                            [opcuaEndpoint,connectionOption,userIdentity]=setEndpoint(msg,opcuaEndpoint,connectionOption,userIdentity);
+                            browseTopic = msg.topic;
+                        }
+                        break;
                     default:
                         break;
                 }
@@ -219,6 +225,24 @@ module.exports = function (RED) {
             node.warn("Browse to root Objects");
             return "ns=0;i=85"; // OPC UA Root Folder Objects
         }
+
+        function setEndpoint(msg,opcuaEndpoint,connectionOption,userIdentity) {//Used for "endpointBrowse"
+            if (msg && msg.OpcUaEndpoint) {
+              opcuaEndpoint = {}; // Clear old endpoint
+              opcuaEndpoint = msg.OpcUaEndpoint; // Check all parameters!
+              connectionOption.securityPolicy = opcua.SecurityPolicy[opcuaEndpoint.securityPolicy]; // || opcua.SecurityPolicy.None;
+              connectionOption.securityMode = opcua.MessageSecurityMode[opcuaEndpoint.securityMode]; // || opcua.MessageSecurityMode.None;
+              //verbose_log("NEW connectionOption security parameters, policy: " + connectionOption.securityPolicy + " mode: " + connectionOption.securityMode);
+              if (opcuaEndpoint.login === true) {
+                userIdentity.userName = opcuaEndpoint.user;
+                userIdentity.password = opcuaEndpoint.password;
+                userIdentity.type = opcua.UserTokenType.UserName;
+                //verbose_log("NEW UserIdentity: " + JSON.stringify(userIdentity));
+              }
+            }
+            node.warn("setEndpoint:" + JSON.stringify(opcuaEndpoint));
+            return [opcuaEndpoint,connectionOption,userIdentity];
+          }
     }
 
     RED.nodes.registerType("OpcUa-Browser", OpcUaBrowserNode);


### PR DESCRIPTION
Add "endpointBrowse" actiontype in order to use the OPCUA Browser node in a subflow.

I have added an example. It will also solve issue #381

For information, I tested "BROWSE" feature with OPCUA client node but it does not give the same features as OPCUA Browser node, therefor I added this feature in Browser node.