### PR TITLE
Fix: Redundant Event Message

### DIFF
--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -194,6 +194,10 @@ module.exports = function (RED) {
 
       verbose_log("EventFields=" + eventFields);
       
+      if (eventFields.length === 0) {
+        node.send(msg);
+      }
+
       async.forEachOf(eventFields, function (variant, index, callback) {
         verbose_log("EVENT Field: " + fields[index] + stringify(variant));
         
@@ -218,7 +222,6 @@ module.exports = function (RED) {
           })
         }
       }, _callback);
-      node.send(msg);
     }
 
     var eventQueue = new async.queue(function (task, callback) {


### PR DESCRIPTION
When subscribed to an OPC UA Event, two messages with the identical message id are sent by the `__dumpEvent` method on monitored item _changed_.
The first message is sent by the `node.send(msg)` call after the `async.forEachOf` loop which can send a message before the event fields are finished collecting within the async loop. The second message is sent within the loop after all of the event fields are finished collecting.

e.g.
![First Message](https://user-images.githubusercontent.com/3209809/169882668-e0b5207b-afb4-4bae-8871-837a31b19ab8.png)
![Second Message](https://user-images.githubusercontent.com/3209809/169882684-00106ad1-b812-4b4e-a2c1-3d325836627d.png)

This PR fixes it so that only one message is sent - either immediately if there are no event fields or once all event fields are collected.