### PR TITLE
Fix ConditionId for Events

### DIFF
--- a/opcua/106-opcuaevent.js
+++ b/opcua/106-opcuaevent.js
@@ -38,8 +38,10 @@ module.exports = function (RED) {
             // All event field, perhaps selectable in UI
 
             var basicEventFields = opcuaBasic.getBasicEventFields();
-            var eventFilter = opcua.constructEventFilter(basicEventFields);
-
+            // Add special select clause entry for Condition at the end
+			var eventFilter = opcua.constructEventFilter(basicEventFields, [opcua.resolveNodeId("ConditionType")]); 
+			basicEventFields.push("ConditionId");
+			
             msg.topic = node.root; // example: ns=0;i=85;
             msg.eventFilter = eventFilter;
             msg.eventFields = basicEventFields;

--- a/opcua/opcua-basics.js
+++ b/opcua/opcua-basics.js
@@ -133,8 +133,7 @@ module.exports.collectAlarmFields = function (field, key, value, payload, node) 
             payload.EventType = value;
             break;
         case "SourceNode":
-            payload.SourceNode = value;     // Fixed on __dumpEvent otherwise not send
-            // payload.ConditionId = value; // UaExpert shows value in the ConditionId field?
+            payload.SourceNode = value;     
             break;
         case "SourceName":
             payload.SourceName = value;
@@ -247,7 +246,6 @@ module.exports.getBasicEventFields = function () {
         "ConditionClassId",
         "ConditionClassName",
         "ConditionName",
-        "ConditionId",
         "BranchId",
         "Retain",
         "EnabledState",


### PR DESCRIPTION
Fixes #448 

- Removed the basically unused getBrowseName and tried to make the code more understandable
- If no ConditionId exists, use EventType as topic. A SourceNode can be source of different events. So I think the EventType is the most interesting property for an event. 
- ConditionId is added with a special operand in the SelectClause of the EventFilter. The ConditionId is not a standard parameter of the conditionType. The ConditionId is the NodeId of the instance of the ConditionType. It is something special and therefore the Operand in the SelectClause is different. See different Operand at bottom of https://reference.opcfoundation.org/v104/Core/docs/Part9/5.5.2/.

_The NodeId of the Condition instance is used as ConditionId. It is not explicitly modelled as a component of the ConditionType. However, it can be requested with the following SimpleAttributeOperand (see [Table 10])_

Please test.