### PR TITLE
Proposal: Auto generate event fields and support custom events

### DIFF
--- a/opcua/106-opcuaevent.html
+++ b/opcua/106-opcuaevent.html
@@ -22,7 +22,8 @@ limitations under the License.
         color:"#3FADB5",
         defaults: {
             root: {value:"", required:true}, 	// ns=2;i=85 Server object to look through all objects under it
-            eventtype: {value:"", required:true}, 		// TODO ui should contain selectable condition types or all
+            eventtype: {value:"", required:true}, 
+            customeventtype: {value:""},
             name: {value:""}
         },
         inputs:1,
@@ -40,8 +41,12 @@ limitations under the License.
 
 <script type="text/x-red" data-template-name="OpcUa-Event">
     <div class="form-row">
-        <label for="node-input-root"><i class="icon-tasks"></i> Root node</label>
+        <label for="node-input-root"><i class="icon-tasks"></i> Source node</label>
         <input type="text" id="node-input-root" placeholder="i=2253">
+    </div>
+    <div class="form-row">
+        <label for="node-input-customeventtype"><i class="icon-tasks"></i> Custom Event Type</label>
+        <input type="text" id="node-input-customeventtype" placeholder="ns=2;i=1234">
     </div>
     <div class="form-row" id="node-input-eventtype-row">
         <label for="node-input-datatype"><i class="icon-tag"></i> Event Type</label>

--- a/opcua/106-opcuaevent.html
+++ b/opcua/106-opcuaevent.html
@@ -22,6 +22,7 @@ limitations under the License.
         color:"#3FADB5",
         defaults: {
             root: {value:"", required:true}, 	// ns=2;i=85 Server object to look through all objects under it
+            activatecustomevent: {value: false, required:true},
             eventtype: {value:"", required:true}, 
             customeventtype: {value:""},
             name: {value:""}
@@ -35,6 +36,32 @@ limitations under the License.
         },
         labelStyle: function() {
             return this.name?"node_label_italic":"";
+        },
+        oneditprepare: function () {
+
+            var node = this;
+
+            try {
+                var inputActivateCustomEvent = $('#node-input-activatecustomevent');
+                var inputCustomEventTypeRow = $('#node-input-customeventtyperow');
+                var inputEventTypeRow = $('#node-input-eventtype-row');
+                adapt_input(); // initialize
+                inputActivateCustomEvent.change(adapt_input);
+
+            } catch (err) {
+                node.error(err);
+            }
+
+            function adapt_input() {
+                if (inputActivateCustomEvent.is(':checked')) {                    
+                    inputCustomEventTypeRow.show();
+                    inputEventTypeRow.hide();
+                }
+                else {                    
+                    inputCustomEventTypeRow.hide();
+                    inputEventTypeRow.show();
+                }
+            }
         }
     });
 </script>
@@ -44,8 +71,12 @@ limitations under the License.
         <label for="node-input-root"><i class="icon-tasks"></i> Source node</label>
         <input type="text" id="node-input-root" placeholder="i=2253">
     </div>
-    <div class="form-row">
-        <label for="node-input-customeventtype"><i class="icon-tasks"></i> Custom Event Type</label>
+    <div class="form-row" id="node-input-activatecustomeventrow">
+        <label for="node-input-activatecustomevent"><i class="icon-tasks"></i> Custom event</label>
+        <input type="checkbox" id="node-input-activatecustomevent" style="width: auto">
+    </div>
+    <div class="form-row" id="node-input-customeventtyperow">
+        <label for="node-input-customeventtype"><i class="icon-tasks"></i> Event Type</label>
         <input type="text" id="node-input-customeventtype" placeholder="ns=2;i=1234">
     </div>
     <div class="form-row" id="node-input-eventtype-row">

--- a/opcua/106-opcuaevent.js
+++ b/opcua/106-opcuaevent.js
@@ -25,28 +25,20 @@ module.exports = function (RED) {
 
         RED.nodes.createNode(this, n);
 
-        this.root = n.root; // OPC UA item nodeID
+        this.root = n.root; // OPC UA item nodeID subscription source
+        this.customeventtype = n.customeventtype;
         this.eventtype = n.eventtype; // eventType
         this.name = n.name; // Node name
 
         var node = this;
 
         node.on("input", function (msg) {
-
-            // var baseEventTypeId = "i=2041";
-            // var serverObjectId = "ns=0;i=2253";
-            // All event field, perhaps selectable in UI
-
-            var basicEventFields = opcuaBasic.getBasicEventFields();
-            // Add special select clause entry for Condition at the end
-			var eventFilter = opcua.constructEventFilter(basicEventFields, [opcua.resolveNodeId("ConditionType")]); 
-			basicEventFields.push("ConditionId");
-			
             msg.topic = node.root; // example: ns=0;i=85;
-            msg.eventFilter = eventFilter;
-            msg.eventFields = basicEventFields;
-            msg.eventTypeIds = node.eventtype; // example: ns=0;i=10751;
-
+            if (node.customeventtype) {
+                msg.eventTypeIds = node.customeventtype; // example: ns=2;i=1234
+            } else {
+                msg.eventTypeIds = node.eventtype; // example: ns=0;i=10751;
+            }
             node.send(msg);
         });
     }

--- a/opcua/106-opcuaevent.js
+++ b/opcua/106-opcuaevent.js
@@ -29,12 +29,15 @@ module.exports = function (RED) {
         this.customeventtype = n.customeventtype;
         this.eventtype = n.eventtype; // eventType
         this.name = n.name; // Node name
+        this.activatecustomevent = n.activatecustomevent;
 
         var node = this;
 
         node.on("input", function (msg) {
             msg.topic = node.root; // example: ns=0;i=85;
-            if (node.customeventtype) {
+
+            if (node.activatecustomevent)
+            {
                 msg.eventTypeIds = node.customeventtype; // example: ns=2;i=1234
             } else {
                 msg.eventTypeIds = node.eventtype; // example: ns=0;i=10751;

--- a/opcua/opcua-basics.js
+++ b/opcua/opcua-basics.js
@@ -73,7 +73,11 @@ function cloneObject(obj) {
     }
 
     throw new Error("Unable to copy obj! Its type isn't supported.");
-}
+};
+
+module.exports.clone_object = function (obj) {
+   return cloneObject(obj);
+};
 
 module.exports.get_timeUnit_name = function (unit) {
 
@@ -119,175 +123,6 @@ module.exports.calc_milliseconds_by_time_and_unit = function (time, unit) {
     }
 
     return time;
-};
-
-module.exports.collectAlarmFields = function (field, key, value, payload, node) {
-    console.log("Collect field: " + field + " key: " + key + " value:" + value + " payload:" + stringify(payload));
-    
-    switch (field) {
-        // Common fields
-        case "EventId":
-            payload.EventId = "0x" + value.toString("hex"); // As in UaExpert
-            break;
-        case "EventType":
-            payload.EventType = value;
-            break;
-        case "SourceNode":
-            payload.SourceNode = value;     
-            break;
-        case "SourceName":
-            payload.SourceName = value;
-            break;
-        case "Time":
-            payload.Time = value;
-            break;
-        case "ReceiveTime":
-            payload.ReceiveTime = value;
-            break;
-        case "Message":
-            payload.Message = value.text;
-            break;
-        case "Severity":
-            payload.Severity = value;
-            break;
-
-        // ConditionType
-        case "ConditionClassId":
-            payload.ConditionClassId = value;
-            break;
-        case "ConditionClassName":
-            payload.ConditionClassNameName = value;
-            break;
-        case "ConditionName":
-            payload.ConditionName = value;
-            break;
-        case "ConditionId":
-            payload.ConditionId = value;
-            break;
-        case "BranchId":
-            payload.BranchId = value;
-            break;
-        case "Retain":
-            payload.Retain = value;
-            break;
-        case "EnabledState":
-            payload.EnabledState = value.text;
-            break;
-        case "Quality":
-            payload.Quality = value;
-            payload.StatusText = value.toString(); // Clear text
-            break;
-        case "LastSeverity":
-            payload.LastSeverity = value;
-            break;
-        case "Comment":
-            payload.Comment = value.text;
-            break;
-        case "ClientUserId":
-            payload.ClientUserId = value;
-            break;
-
-            // AcknowledgeConditionType
-        case "AckedState":
-            payload.AckedState = value.text;
-            break;
-        case "ConfirmedState":
-            payload.ConfirmedState = value.text;
-            break;
-
-            // AlarmConditionType
-        case "ActiveState":
-            payload.ActiveState = value.text;
-            break;
-        case "InputNode":
-            payload.InputNode = value;
-            break;
-        case "SupressedState":
-            payload.SupressedState = value.text;
-            break;
-
-            // Limits
-        case "HighHighLimit":
-            payload.HighHighLimit = value;
-            break;
-        case "HighLimit":
-            payload.HighLimit = value;
-            break;
-        case "LowLimit":
-            payload.LowLimit = value;
-            break;
-        case "LowLowLimit":
-            payload.LowLowLimit = value;
-            break;
-        case "Value":
-            payload.Value = value;
-            break;
-        default:
-            payload[field] = cloneObject(value);
-            break;
-    }
-};
-
-
-module.exports.getBasicEventFields = function () {
-
-    return [
-        // Common fields
-        "EventId",
-        "EventType",
-        "SourceNode",
-        "SourceName",
-        "Time",
-        "ReceiveTime",
-        "Message",
-        "Severity",
-
-        // ConditionType
-        "ConditionClassId",
-        "ConditionClassName",
-        "ConditionName",
-        "BranchId",
-        "Retain",
-        "EnabledState",
-        "Quality",
-        "LastSeverity",
-        "Comment",
-        "ClientUserId",
-
-        // AcknowledgeConditionType
-        "AckedState",
-        "ConfirmedState",
-
-        // AlarmConditionType
-        "ActiveState",
-        "InputNode",
-        "SuppressedState",
-
-        // Limits
-        "HighLimit",
-        "LowLimit",
-        "HighHighLimit",
-        "LowLowLimit",
-
-        // AutoIdScanEventType & AutoIdDiagnosisEventType
-        "3:DeviceName",
-
-        // AutoIdScanEventType
-        "3:ScanResult",
-
-        // AutoIdDiagnosisEventType
-        "4:DeviceName",
-
-        // AutoIdLastAccessEventType
-        "4:Client",
-        "4:Command",
-        "4:LastAccessResult",
-
-        // AutoIdPresenceEventType
-        "4:Presence",
-
-        "Value"
-    ];
 };
 
 /*


### PR DESCRIPTION
This proposal auto generates all EventFields and supports custom events. Solves #410.

I am not sure what is the best compatible or incompatible way. I tried to extend the current Event-Node as compatible as possible. But is that the best way? Or is it better to create a new additional Event Node in the library? Or to do a really incompatible breaking change?

In the proposal I added the entry field "Custom Event Type". If there is content in that field, the Event Type selection is ignored, otherwise "Event Type" is used. So "Custom Event Type" wins over "Event Type". Also I renamed Root node to Source node in the UI, since there are use cases to subscribe for special events on other nodes.

@mikakaraila What do you think?
 
![image](https://user-images.githubusercontent.com/26673978/184437080-4b47d3ef-1609-485f-9b08-2559c2332d76.png)

I also think the format of the EventFields should not be manipulated with EventId being the sole exception. All other fields should stay in the auto generated format.

The library function "opcua.extractConditionFields" works universal for all EventTypes, just the ConditionId field needs to be removed. @erossignon it would be great to have "extractEventFields" somewhere in the library with exact the same code, but without adding the ConditionId field.

Next step I am planning is to add a proper automatic whereClause in the eventFilter.
