### PR TITLE
Feature: Extension Object Array Write

### DIFF
--- a/opcua/101-opcuaitem.html
+++ b/opcua/101-opcuaitem.html
@@ -77,7 +77,8 @@ limitations under the License.
             <option value="Float Array">Float Array</option>
             <option value="Double Array">Double Array</option>
             <option value="Boolean Array">Boolean Array</option>
-            <option value="Extension Object">ExtensionObject</option>
+            <option value="ExtensionObject">ExtensionObject</option>
+            <option value="ExtensionObject Array">ExtensionObject Array</option>
         </select>
     </div>
     <div class="form-row">

--- a/opcua/101-opcuaitem.html
+++ b/opcua/101-opcuaitem.html
@@ -77,8 +77,8 @@ limitations under the License.
             <option value="Float Array">Float Array</option>
             <option value="Double Array">Double Array</option>
             <option value="Boolean Array">Boolean Array</option>
-            <option value="ExtensionObject">ExtensionObject</option>
-            <option value="ExtensionObject Array">ExtensionObject Array</option>
+            <option value="Extension Object">ExtensionObject</option>
+            <option value="Extension Object Array">ExtensionObject Array</option>
         </select>
     </div>
     <div class="form-row">

--- a/opcua/101-opcuaitem.js
+++ b/opcua/101-opcuaitem.js
@@ -27,7 +27,7 @@ module.exports = function (RED) {
         RED.nodes.createNode(this, n);
 
         this.item = n.item; // OPC UA address: ns=2;i=4 OR ns=3;s=MyVariable
-        this.datatype = n.datatype; // String;
+        this.datatype = n.datatype.replace(/\s/g, ""); // String; need to remove white space from node datatype to be consistent with inputs, i.e. ExtensionObject
         this.value = n.value; // 66.6
         this.name = n.name; // browseName shall be put here
 

--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -1106,7 +1106,7 @@ module.exports = function (RED) {
       verbose_log("NodeId= " + nodeid.toString() + " type=" + msg.datatype);
 
       var opcuaDataValue = msg.datatype && msg.datatype.indexOf("ExtensionObject") >= 0 && node.session
-        ? await build_new_extensionObject_dataValue(msg.dataType, msg.topic, msg.payload, node.session)
+        ? await build_new_extensionObject_dataValue(msg.datatype, msg.topic, msg.payload, node.session)
         : opcuaBasics.build_new_dataValue(msg.datatype, msg.payload);
 
       async function build_new_extensionObject_dataValue(datatype, topic, payload, session) {

--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -1112,7 +1112,7 @@ module.exports = function (RED) {
       async function build_new_extensionObject_dataValue(datatype, topic, payload, session) {
         var defaultExtensionObject = null;
 
-        if (topic.indexOf("typeId=")) {
+        if (topic.indexOf("typeId=") > 0) {
           var typeId = topic.substring(topic.indexOf("typeId=") + 7);
           verbose_log("ExtensionObject TypeId= " + typeId);
           defaultExtensionObject = await session.constructExtensionObject(opcua.coerceNodeId(typeId), {}); // Create first with default values
@@ -1121,7 +1121,7 @@ module.exports = function (RED) {
 
         var nValue = null;
 
-        if (datatype.indexOf("Array")) {
+        if (datatype.indexOf("Array") > 0) {
           // datatype is array of extension object
           payload.value.forEach(function (extensionObject, index) {
             // deep clone default extension object

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "chalk": "4.1.2",
     "env-paths": "2.2.1",
     "flatted": "^3.2.2",
+    "lodash.clonedeep": "^4.5.0",
     "node-opcua": "2.73.0",
     "node-opcua-file-transfer": "2.73.0"
   },


### PR DESCRIPTION
- Adding support for writing extension object arrays.
- Removing white space from OPC UA Item node's datatype property to be consistent with input datatypes, i.e. `Extension Object` -> `ExtensionObject`, and also avoid breaking existing OPC UA Item nodes.
- Adding `lodash.clonedeep` dependency for efficient object deep cloning.

![image](https://user-images.githubusercontent.com/3209809/184947116-58761621-2a74-42cd-95f5-0505e8cc8422.png)

![image](https://user-images.githubusercontent.com/3209809/184946782-673c399b-07cf-4c8e-92c1-4da524e52d46.png)

![image](https://user-images.githubusercontent.com/3209809/184947589-5f73d4c4-84a8-4d67-9441-d7da9e84ed98.png)

@mikakaraila  - do you have any automated tests or tests flows I should run these changes through before submitting the PR? Looks like the last changes I made with the event messages broke events even though it looked like it was working from my side.