### PR TITLE
Events add filter whereClause for EventType

### DIFF
--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -1883,20 +1883,28 @@ module.exports = function (RED) {
     }
 
     async function subscribe_events_async(msg) {
-      var fields = await opcua.extractConditionFields(node.session, msg.eventTypeIds); // works with all eventTypes
+      verbose_log("subscribing events for " + msg.eventTypeIds);
+      var eventTypeId = opcua.resolveNodeId(msg.eventTypeIds);
+      var fields = await opcua.extractConditionFields(node.session, eventTypeId); // works with all eventTypes
       fields.splice(fields.indexOf("ConditionId"), 1); // remove field ConditionId
-  
+
       // If field "ConditionClassId" is part of the list, it is or inherits from ConditionType
       if (fields.includes("ConditionClassId")) {
-        msg.eventFilter = opcua.constructEventFilter(fields, [opcua.resolveNodeId(msg.eventTypeIds)]); 
+        msg.eventFilter = opcua.constructEventFilter(fields, [eventTypeId]); 
         fields.push("ConditionId");
       } else {
         msg.eventFilter = opcua.constructEventFilter(fields);
       }
+
+      // Create special whereClause if not BaseEventType
+      var baseEventType = opcua.resolveNodeId("BaseEventType");
+      if (eventTypeId.toString() != baseEventType.toString()) {
+        msg.eventFilter.whereClause = await create_where_clause_from_eventtype(eventTypeId);
+      }
       
       msg.eventFields = fields;
-      verbose_log(msg.eventFields);
-   
+      verbose_log("EventFields: " + msg.eventFields);
+      
       if (!subscription) {
         // first build and start subscription and subscribe on its started event by callback
         var timeMilliseconds = opcuaBasics.calc_milliseconds_by_time_and_unit(node.time, node.timeUnit);
@@ -1918,8 +1926,58 @@ module.exports = function (RED) {
     }
 
     function subscribe_events_input(msg) {
-      verbose_log("subscribing events");
       subscribe_events_async(msg);
+    }
+
+    async function create_where_clause_from_eventtype(eventTypeId) {
+      var eventTypeIdList = await get_type_and_subtypes_of_eventype(eventTypeId);
+      verbose_log("whereClause EventTypes: " + eventTypeIdList);
+
+      // First operand defines the field of each incoming event which is compared against the given list
+      var operands = [new opcua.SimpleAttributeOperand({
+                                  attributeId: AttributeIds.Value,
+                                  browsePath: [opcua.coerceQualifiedName("EventType")],                                
+                                  typeDefinitionId: new opcua.NodeId()})];
+      
+      // Further operands define the given list of EventTypes to compare against
+      for (var i = 0; i < eventTypeIdList.length; i++) {
+        var typeId = eventTypeIdList[i];
+        var opValue = new opcua.Variant({dataType: opcua.DataType.NodeId, value: opcua.resolveNodeId(typeId)});
+        operands.push(new opcua.LiteralOperand({value: opValue}));
+      }
+      
+      // Operator is "InList"
+      var contentFilterElement = new opcua.ContentFilterElement({filterOperator: opcua.FilterOperator.InList,  
+                                                                 filterOperands: operands});
+      var whereClause = new opcua.ContentFilter({elements: [contentFilterElement]});
+      return whereClause;
+    }
+
+    async function get_type_and_subtypes_of_eventype(eventTypeId, eventTypeIdList=null) {
+      if (!eventTypeIdList) {
+        eventTypeIdList = [eventTypeId];
+      }
+      var children = await get_subtype_children_of_node(node.session, eventTypeId);
+      verbose_log("SubType Children: " + children.map((e) => {return e.browseName}));
+      
+      for (var i = 0; i < children.length; i++) {
+        var childNodeId = children[i].nodeId;
+        eventTypeIdList.push(childNodeId);
+        await get_type_and_subtypes_of_eventype(childNodeId, eventTypeIdList);
+      }
+      return eventTypeIdList;
+    }
+
+    async function get_subtype_children_of_node(session, nodeId) {
+      const browseResult = await session.browse({
+          browseDirection:opcua.BrowseDirection.Forward,
+          includeSubtypes: true,
+          nodeClassMask: 0, // 0 = all nodes
+          nodeId: opcua.resolveNodeId(nodeId),
+          referenceTypeId: opcua.resolveNodeId("HasSubtype"), 
+          resultMask: 0x3f // All
+      });
+      return browseResult.references || []; 
     }
 
     function reconnect(msg) {

--- a/opcua/106-opcuaevent.html
+++ b/opcua/106-opcuaevent.html
@@ -99,7 +99,12 @@ limitations under the License.
 </script>
 
 <script type="text/x-red" data-help-name="OpcUa-Event">
-    <p>Defines OPC UA events that will be subscribed from the server.</p>
-	<p>Server root node will used to look selected events under it.</p>
-	<p>Condition type can be left empty then all alarm / event objects will be taken into account.</p>
+    <p>Defines the OPC UA events that will be subscribed from the server.</p>
+	<p>The Source node defines the node where events are subscribed for. 
+       The root Server node id is used, if all events of the server shall be processed. 
+       If available, other specific node ids can be used for a subset of events.
+       Not using the root Server node might for example make sense in case of an aggregating server.</p>
+    <p>The Event Type defines what kind of events are subscribed. Events of the given Event Type and all subtypes are returned.
+       An event type can be selected in the dropdown field, or manually entered when marking the checkbox.
+    </p>
 </script>


### PR DESCRIPTION
This PR finishes a first generic implementation for events. 

An auto-generated whereClause is added to the EventFilter. 

Now only events of the given EventType and all of its subtypes are returned.

On the long run the code to create the whereClause should be moved to the node-opcua library in "constructEventFilter".