### PR TITLE
Fix: Outputting ExtensionObjects to Multiple Debug Nodes

### DIFF
--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -1145,7 +1145,7 @@ module.exports = function (RED) {
           }
           // Simplified
           newmsg.topic = msg.topic;
-          newmsg.payload = ExtensionData; //  JSON.stringify(ExtensionData); // New value with default values
+          newmsg.payload = JSON.parse(JSON.stringify(ExtensionData)); //  JSON.stringify(ExtensionData); // New value with default values
           verbose_log("Extension Object msg: " + stringify(newmsg))
           node.send(newmsg);
         }

--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -839,7 +839,11 @@ module.exports = function (RED) {
                     verbose_log("UInt16:" + dataValue.value.value + " -> Int32:" + opcuaBasics.toInt32(dataValue.value.value));
                   }
 
-                  msg.payload = dataValue.value.value;
+                  // clone payload via JSON stringify/parse only if datavalue is an ExtensionObject or an array of ExtensionObjects
+                  msg.payload = dataValue.value.dataType === opcua.DataType.ExtensionObject
+                    ? JSON.parse(JSON.stringify((dataValue.value.value)))
+                    : dataValue.value.value;
+
                   msg.statusCode = dataValue.statusCode;
                   msg.serverTimestamp = dataValue.serverTimestamp;
                   msg.sourceTimestamp = dataValue.sourceTimestamp;
@@ -1038,10 +1042,15 @@ module.exports = function (RED) {
                   if (sourceTs === null) {
                     sourceTs = new Date();
                   }
+
+                  var value = dataValue.value.dataType === opcua.DataType.ExtensionObject
+                    ? JSON.parse(JSON.stringify(dataValue.value.value))
+                    : dataValue.value.value;
+
                   // Use nodeId in topic, arrays are same length
                   node.send({
                     topic: multipleItems[i],
-                    payload: dataValue.value.value,
+                    payload: value,
                     serverTimestamp: serverTs,
                     sourceTimestamp: sourceTs
                   });
@@ -1536,10 +1545,15 @@ module.exports = function (RED) {
           verbose_log("Group change on item, index: " + index + " item: " + monitorItems[index].nodeId + " value: " + dataValue.value.value);
           // verbose_log("Change detected: " + monitoredItem.toString() + " " + dataValue.toString() + " " + index);
           const nodeId = monitorItems[index].nodeId.toString();
+
+          var value = dataValue.value.dataType === opcua.DataType.ExtensionObject
+            ? JSON.parse(JSON.stringify(dataValue))
+            : dataValue;
+
           if (nodeId) {
             var msg = {};
             msg.topic = nodeId;
-            msg.payload = dataValue; // if users want to get dataValue.value.value example contains function node
+            msg.payload = value; // if users want to get dataValue.value.value example contains function node
             node.send(msg);
           }
         });


### PR DESCRIPTION
There's a reported issue when reading extension objects and sending the message containing the extension objects to more than one debug node (#351, #426), where we get the error message `TypeError: encodeObject Error: [Cannot read property 'schema' of undefined]`.

The issue also occurs when sending a message to two debug nodes containing an extension object created by the `BUILD` action of a client.
![image](https://user-images.githubusercontent.com/3209809/187243547-1a9e17a8-b518-49f7-9007-f8cc9c4dac11.png)
![image](https://user-images.githubusercontent.com/3209809/187243723-d853a695-19d8-436f-a26d-e509386224a1.png)

I think there's an underlying issue with how the debug node interacts with the cloned extension objects when displaying it in the Node-RED UI, where only the first message is interpreted correctly. I first tried to workaround the issue by creating a deep copy of the extension object in the message using `lodash.cloneDeep`, but still ran into the issue. When I created a copy using `JSON.parse/stringify`, the issue was resolved.
The flow below has the same effect.
![image](https://user-images.githubusercontent.com/3209809/187245425-d1e08a01-cfd1-4c57-98b4-36072d541330.png)
![image](https://user-images.githubusercontent.com/3209809/187250570-58ec22d8-cf36-4ddf-99c1-fe9ce9ae4c21.png)

While we can ignore the second debug's node's error message, any subsequent debug nodes in the flow that receives a message containing the extension object will also error. This can confuse users that an error occurred when it's just a display error - it can also conceal actual error messages.

Copying the extension object via `JSON.parse/stringify` properly displays the extension object in multiple debug nodes, but comes at the extra performance cost of copying the extension object. I don't think there's a risk of data loss since the extension objects shouldn't contain functions/methods?

What do you think @mikakaraila? Is this something we should just handle in the node code, add documentation so that users are aware of this behavior and how to work around it, or further investigate in the `node-opcua` project?