### PR TITLE
Fix member access of null value in verbose_log

### DIFF
--- a/opcua/104-opcuaserver.js
+++ b/opcua/104-opcuaserver.js
@@ -647,8 +647,9 @@ module.exports = function (RED) {
                         verbose_log("findNode(ns="+ns+";s="+payload.variableName);
                         var vnode = addressSpace.findNode("ns="+ns+";s="+payload.variableName);
                     }
-                    verbose_log("Found variable, nodeId: " + vnode.nodeId);
                     if (vnode) {
+                        verbose_log("Found variable, nodeId: " + vnode.nodeId);
+
                         variables[payload.variableName] = opcuaBasics.build_new_value_by_datatype(payload.datatype, payload.variableValue);
                         // var newValue = opcuaBasics.build_new_variant(payload.datatype, payload.variableValue);
                         var newValue = opcuaBasics.build_new_dataValue(payload.datatype, payload.variableValue);


### PR DESCRIPTION
Prevent TypeError when variable is not found: `Cannot read properties of null (reading 'nodeId')`.

A call to verbose_log precedes the null-check, and should be called only if the vnode (variable node) is found and not-null.