### PR TITLE
Refactor user with roles

### DIFF
--- a/opcua/104-opcuaserver.js
+++ b/opcua/104-opcuaserver.js
@@ -88,7 +88,7 @@
         var initialized = false;
         var folder = null;
         let userManager; // users with username, password and role
-        let users = [{ username: "", password: "", role: "" }]; // Empty as default
+        let users = [{ username: "", password: "", roles: "" }]; // Empty as default
         let savedAddressSpace = "";
 
         if (node.users && node.users.length > 0) {

--- a/opcua/104-opcuaserver.js
+++ b/opcua/104-opcuaserver.js
@@ -159,19 +159,8 @@
                         // Check this TODO
                         return opcua.makeRoles("AuthenticatedUser"); // opcua.WellKnownRoles.Anonymous; // by default were guest! ( i.e anonymous), read-only access 
                     }
-                    const userRole = users[uIndex].role;
-                    // Default available roles, note each variable / methods should have permissions for real use case
-                    if (userRole === "Anonymous") return opcua.makeRoles("Anonymous"); // opcua.WellKnownRoles.Anonymous;
-                    if (userRole === "Guest") return opcua.makeRoles("AuthenticatedUser"); // opcua.WellKnownRoles.AuthenticatedUser;
-                    if (userRole === "Engineer") return opcua.makeRoles("Engineer"); // opcua.WellKnownRoles.Engineer;
-                    if (userRole === "Observer") return opcua.makeRoles("Observer"); // opcua.WellKnownRoles.Observer;
-                    if (userRole === "Operator") return opcua.makeRoles("Operator"); // return opcua.WellKnownRoles.Operator;
-                    if (userRole === "ConfigureAdmin") return opcua.makeRoles("ConfigureAdmin"); // return opcua.WellKnownRoles.ConfigureAdmin;
-                    if (userRole === "SecurityAdmin") return  pcua.makeRoles("SecurityAdmin"); // return opcua.WellKnownRoles.SecurityAdmin;
-                    if (userRole === "Supervisor") return opcua.makeRoles("Supervisor"); // return opcua.WellKnownRoles.Supervisor;
-
-                    // Return configurated role
-                    return userRole;
+                    const userRoles = users[uIndex].roles;
+                    return opcua.makeRoles(userRoles);
                 }
             };
         }

--- a/users.json
+++ b/users.json
@@ -2,21 +2,21 @@
     {
       "username": "visitor",
       "password": "qwerty",
-      "role": "Guest"
+      "roles": "Guest"
     },
     {
       "username": "JohnSmith",
       "password": "1234",
-      "role": "Operator"
+      "roles": "Operator"
     },
     {
       "username": "James",
       "password": "Bond",
-      "role": "Observer"
+      "roles": "Observer"
     },
     {
       "username": "Administrator",
       "password": "HardPassword!",
-      "role": "ConfigureAdmin"
+      "roles": "Supervisor;ConfigureAdmin;SecurityAdmin"
     }
   ]


### PR DESCRIPTION
Hey @mikakaraila the server currently supports only one role per user but in reality one user can have many roles:

node-opcua defines the roles string for "makeRoles()" seperated with ";"

![grafik](https://user-images.githubusercontent.com/56362817/200259556-6351fdff-6356-4b3f-9c46-54db4f3bc593.png)

like ```"roles":"Supervisor;ConfigureAdmin;SecurityAdmin"``` for the WellKnownRoles

![grafik](https://user-images.githubusercontent.com/56362817/200259074-10e72a9a-9b98-4eaf-a847-9164a1e9a720.png)
