### PR TITLE
Only disconnect when connected

### DIFF
--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -303,17 +303,19 @@ module.exports = function (RED) {
     function close_opcua_client(message, error) {
       if (node.client) {
         try {
-          node.client.disconnect(function () {
-            node.client = null;
-            verbose_log("Client disconnected!");
-            if (error === 0) {
-              set_node_status_to("closed");
-            }
-            else {
-              set_node_errorstatus_to(message, error)
-              node.error("Client disconnected & closed: " + message + " error: " + error.toString());
-            }
-          });
+          if(!node.client.isReconnecting){
+            node.client.disconnect(function () {
+              node.client = null;
+              verbose_log("Client disconnected!");
+              if (error === 0) {
+                set_node_status_to("closed");
+              }
+              else {
+                set_node_errorstatus_to(message, error)
+                node.error("Client disconnected & closed: " + message + " error: " + error.toString());
+              }
+            });
+          }
         }
         catch (err) {
           node_error("Error on disconnect: " + stringify(err));


### PR DESCRIPTION
I think this might be related to #388.

There's an issue whenever 2 or more OPCUA Client nodes are still connecting to a server and Node-RED flows are redeployed, as it will try to dispose a node that's not connected.
```
2023-03-14 17:04:58 14 Mar 16:04:58 - [error] Error: Already disposing
2023-03-14 17:04:58     at OPCUACertificateManager.<anonymous> (/node_modules/node-opcua-pki/dist/pki/certificate_manager.js:461:23)
2023-03-14 17:04:58     at Generator.next (<anonymous>)
2023-03-14 17:04:58     at /node_modules/node-opcua-pki/dist/pki/certificate_manager.js:32:71
2023-03-14 17:04:58     at new Promise (<anonymous>)
2023-03-14 17:04:58     at __awaiter (/node_modules/node-opcua-pki/dist/pki/certificate_manager.js:28:12)
2023-03-14 17:04:58     at OPCUACertificateManager.dispose (/node_modules/node-opcua-pki/dist/pki/certificate_manager.js:459:16)
2023-03-14 17:04:58     at OPCUACertificateManager.<anonymous> (/node_modules/node-opcua-certificate-manager/dist/certificate_manager.js:58:38)
2023-03-14 17:04:58     at Generator.next (<anonymous>)
2023-03-14 17:04:58     at /node_modules/node-opcua-certificate-manager/dist/certificate_manager.js:8:71
2023-03-14 17:04:58     at new Promise (<anonymous>)
```

For some reason, neither the `catch` nor the error callback are picking the error up, but it seems like checking if the client is reconnecting before trying to disconnect is a reasonable fix.