### PR TITLE
Better reconnection handling

### DIFF
--- a/opcua/opcua-basics.js
+++ b/opcua/opcua-basics.js
@@ -267,6 +267,7 @@ module.exports.get_node_status = function (statusValue) {
         case "keepalive":
         case "nodeId stored":
         case "clear items":
+        case "executing method":
             fillValue = "green";
             shapeValue = "ring";
             break;
@@ -293,6 +294,7 @@ module.exports.get_node_status = function (statusValue) {
         case "subscribed":
         case "browse done":
         case "changed":
+        case "method executed":
             fillValue = "green";
             shapeValue = "dot";
             break;
@@ -302,6 +304,7 @@ module.exports.get_node_status = function (statusValue) {
         case "connection error":
         case "node error":
         case "terminated":
+        case "no client":
             fillValue = "red";
             shapeValue = "ring";
             break;


### PR DESCRIPTION
Related to #528.

Due to the previous changes on #528, some issues appeared. Since there was no global client on the code, a redeploy could cause issues with different listeners and some additional things were not correctly handled. 

Now, there is a global client (like in the opcUA client node) but `keepAlive` is still set to false, and a `connect`-`disconnect` is done with every method message.

However, if the node is (re)connecting while a new message arrives, it will be queued (again, similar to the client node) until the connection is (re)gained.

Hope it makes sense and sorry for not getting it right on the first PR.

Thanks!