### PR TITLE
Update 107-opcuamethod.js

### DIFF
--- a/opcua/107-opcuamethod.js
+++ b/opcua/107-opcuamethod.js
@@ -355,7 +355,7 @@ module.exports = function (RED) {
             if (arg.dataType === "ExtensionObject") {
               var extensionobject = null;
               if (arg.typeid) {
-                extensionObject = await node.session.constructExtensionObject(opcua.coerceNodeId(arg.typeid), {}); // TODO make while loop to enable await
+                extensionobject = await node.session.constructExtensionObject(opcua.coerceNodeId(arg.typeid), {}); // TODO make while loop to enable await
               }
               verbose_log("ExtensionObject=" + stringify(extensionobject));
               Object.assign(extensionobject, arg.value);


### PR DESCRIPTION
(I assume) wrong casing used in variable definition, leading to "Invalid NodeId: ReferenceError: extensionObject is not defined" when trying to use extensionObjects in method calls