### PR TITLE
OPC Server Node maxSessions property added.

### DIFF
--- a/opcua/104-opcuaserver.html
+++ b/opcua/104-opcuaserver.html
@@ -51,7 +51,8 @@ limitations under the License.
             maxNodesPerTranslateBrowsePathsToNodeIds: {value: 0, required: false},
             maxConnectionsPerEndpoint: {value: 20, required: false},
             maxMessageSize: {value: 4096, required: false},
-            maxBufferSize: {value: 4096, required: false}
+            maxBufferSize: {value: 4096, required: false},
+            maxSessions: {value: 20 , required: false}
         },
         inputs:1,
         outputs:1,
@@ -194,6 +195,10 @@ limitations under the License.
         <label for="node-input-maxBufferSize" style="width:72%;"><i class="icon-tasks"></i> maxBufferSize</label>
         <input type="number" id="node-input-maxBufferSize" placeholder="4096" style="max-width:100px">
     </div>
+    <div class="form-row">
+        <label for="node-input-maxSessions" style="width:72%;"><i class="icon-tasks"></i> maxSessions</label>
+        <input type="number" id="node-input-maxSessions" style="max-width:100px">
+    </div>
 </script>
 
 <script type="text/x-red" data-help-name="OpcUa-Server">
@@ -205,6 +210,7 @@ limitations under the License.
     <p>Server active endpoints from security mode and policy:</p>
     <p>Security mode: None Sign SignAndEncrypt<p>
     <p>Security policy: Basic128-Rsa15 | Basic256 | Basic128-Sha256<p>
+    <p>maxSessions: Maximum number of sessions allowed by the server, default 20. Changing might impact performance.<p>    
     <p>
         OPC UA server commands:
         <ul>

--- a/opcua/104-opcuaserver.js
+++ b/opcua/104-opcuaserver.js
@@ -63,6 +63,11 @@
         this.maxNodesPerTranslateBrowsePathsToNodeIds = n.maxNodesPerTranslateBrowsePathsToNodeIds;
         this.registerToDiscovery = n.registerToDiscovery;
         this.constructDefaultAddressSpace = n.constructDefaultAddressSpace;
+                       
+        this.maxSessions =  Math.max(1,n.maxSessions); // Always have minimum of 1 session.
+        
+
+
         var maxConnectionsPerEndpoint = 20;
         if (n.maxConnectionsPerEndpoint > 20) {
             maxConnectionsPerEndpoint = n.maxConnectionsPerEndpoint;
@@ -285,7 +290,7 @@
                 serverCapabilities: {
                   maxBrowseContinuationPoints: 10,
                   maxHistoryContinuationPoints: 10,
-                  maxSessions: 20,
+                  maxSessions: node.maxSessions,
                   // maxInactiveLockTime,
                   // Get these from the node parameters
                   operationLimits: {


### PR DESCRIPTION
For my project i need more sessions on the OPC Server then the static allowed maximum number of 20 sessions.
For this added an extra property on the node OpcUa - Server which initialises on the default 20. 

This allowed me to use the OPC server as a central server in my project, hope this helps others as well.