### PR TITLE
remove confusing folderName4PKI in favor of a single PKI location

### DIFF
--- a/opcua/102-opcuaclient.html
+++ b/opcua/102-opcuaclient.html
@@ -33,7 +33,6 @@ limitations under the License.
             localkeyfile: {value: ""},
             securitymode: {value: "None"},
             securitypolicy: {value: "None"},
-            folderName4PKI: {value: ""},
             useTransport: {value: false, required: false},
             maxChunkCount: {value: 1, required: false},
             maxMessageSize: {value: 8192, required: false}, // should be at least 8192
@@ -150,10 +149,6 @@ limitations under the License.
 	<div class="form-row">
         <label for="node-input-path"><i class="icon-tasks"></i> Local private key file with absolute path</label>
         <input type="text" id="node-input-localkeyfile" placeholder="private_key.pem">
-    </div>
-    <div class="form-row">
-        <label for="node-input-folderName4PKI"><i class="icon-tasks"></i> PKI certificate folder</label>
-        <input type="text" id="node-input-folderName4PKI" placeholder="">
     </div>
     <div class="form-row">
         <label for="node-input-useTransport"><i class="icon-tasks"></i> Use transport settings</label>

--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -47,8 +47,7 @@ module.exports = function (RED) {
   // var subscription_service = require("node-opcua-service-subscription");
 
   const { createClientCertificateManager } = require("./utils");
-  const { dumpCertificates } = require("./dump_certificates");
-
+ 
   const {parse, stringify} = require('flatted');
 
   function OpcUaClientNode(n) {
@@ -63,7 +62,6 @@ module.exports = function (RED) {
     this.certificate = n.certificate; // n == NONE, l == Local file, e == Endpoint, u == Upload
     this.localfile = n.localfile; // Local certificate file
     this.localkeyfile = n.localkeyfile; // Local private key file
-    this.folderName4PKI = n.folderName4PKI; // Storage folder for PKI and certificates
     this.useTransport = n.useTransport;
     this.maxChunkCount = n.maxChunkCount;
     this.maxMessageSize = n.maxMessageSize
@@ -91,10 +89,7 @@ module.exports = function (RED) {
     var userCertificate = opcuaEndpoint.userCertificate;
     var userPrivatekey = opcuaEndpoint.userPrivatekey;
 
-    if (node.folderName4PKI && node.folderName4PKI.length>0) {
-      verbose_log("Node: " + node.name + " using own PKI folder:" + node.folderName4PKI);
-    }
-    connectionOption.clientCertificateManager = createClientCertificateManager(true, node.folderName4PKI); // AutoAccept certificates, TODO add to client node as parameter if really needed
+    connectionOption.clientCertificateManager = createClientCertificateManager();
 
     if (node.certificate === "l" && node.localfile) {
       verbose_log("Using 'own' local certificate file " + node.localfile);

--- a/opcua/104-opcuaserver.html
+++ b/opcua/104-opcuaserver.html
@@ -26,7 +26,6 @@ limitations under the License.
             endpoint: {value: ""},
             users: {value: "users.json"},
             nodesetDir: {value: ""},
-            folderName4PKI: {value: ""},
             autoAcceptUnknownCertificate: {value: true},
             registerToDiscovery: {value: false},
             constructDefaultAddressSpace: {value: true},
@@ -90,10 +89,6 @@ limitations under the License.
     <div class="form-row">
         <label for="node-input-nodesetDir"><i class="icon-tasks"></i> Custom nodeset directory</label>
         <input type="text" id="node-input-nodesetDir" placeholder="">
-    </div>
-    <div class="form-row">
-        <label for="node-input-folderName4PKI"><i class="icon-tasks"></i> PKI certificate folder</label>
-        <input type="text" id="node-input-folderName4PKI" placeholder="">
     </div>
     <div class="form-row">
         <label for="node-input-autoAcceptUnknownCertificate" style="width:72%;"><i class="icon-tasks"></i> Auto Accept Unknown Certificates</label>

--- a/opcua/104-opcuaserver.js
+++ b/opcua/104-opcuaserver.js
@@ -29,7 +29,7 @@
     var opcuaBasics = require('./opcua-basics');
     const {parse, stringify} = require('flatted');
     const { createServerCertificateManager, createUserCertificateManager } = require("./utils");
-    const { ExtensionObject } = require("node-opcua-extension-object");
+   
     function OpcUaServerNode(n) {
 
         RED.nodes.createNode(this, n);
@@ -39,7 +39,6 @@
         this.endpoint = n.endpoint;
         this.users = n.users;
         this.nodesetDir = n.nodesetDir;
-        this.folderName4PKI = n.folderName4PKI; // Storage folder for PKI and certificates
         this.autoAcceptUnknownCertificate = n.autoAcceptUnknownCertificate;
         this.allowAnonymous = n.allowAnonymous;
         this.endpointNone = n.endpointNone;
@@ -254,8 +253,8 @@
             verbose_log("Create Server from XML ...");
             // DO NOT USE "%FQDN%" anymore, hostname is OK
             const applicationUri =  opcua.makeApplicationUrn(os.hostname(), "node-red-contrib-opcua-server");
-            const serverCertificateManager = createServerCertificateManager(node.autoAcceptUnknownCertificate, node.folderName4PKI);
-            const userCertificateManager = createUserCertificateManager(node.autoAcceptUnknownCertificate, node.folderName4PKI);
+            const serverCertificateManager = createServerCertificateManager();
+            const userCertificateManager = createUserCertificateManager();
 
 
             var registerMethod = null;

--- a/opcua/utils.js
+++ b/opcua/utils.js
@@ -5,76 +5,39 @@ const envPaths = require("env-paths");
 const config = envPaths("node-red-opcua").config;
 
 
-let _g_clientCertificateManager = null;
+let _g_CertificateManager = null;
 
-function createClientCertificateManager(autoAccept, folderName) {
-    return createCertificateManager(false, autoAccept, folderName);
+function createCertificateManager() {
+    if (_g_CertificateManager) return _g_CertificateManager;
+    let folder = config;
+    _g_CertificateManager = new opcua.OPCUACertificateManager({
+        name: "PKI",
+        rootFolder: path.join(folder, "PKI"),
+        automaticallyAcceptUnknownCertificate: true
+    });
+    return _g_CertificateManager;
+}
+function createClientCertificateManager() {
+    return createCertificateManager();
 }
 
-function createServerCertificateManager(autoAccept, folderName) {
-    return createCertificateManager(true, autoAccept, folderName);
+function createServerCertificateManager() {
+    return createCertificateManager();
 }
 
-function createCertificateManager(isServer, autoAccept, folderName) {
-    if (folderName && folderName.length > 0) {
-        if (path.isAbsolute(folderName)) {
-            folder = folderName;
-        }
-        else {
-            folder = config.replace("Config", folderName);
-        }
-        return new opcua.OPCUACertificateManager({
-            name: "PKI",
-            rootFolder: path.join(folder, "PKI"),
-            automaticallyAcceptUnknownCertificate: autoAccept
-        });
-    }
-    else {
-        folder = config;
-        if (isServer) {
-            return new opcua.OPCUACertificateManager({
-                name: "PKI",
-                rootFolder: path.join(folder, "PKI"),
-                automaticallyAcceptUnknownCertificate: autoAccept
-            });
-        } else if (_g_clientCertificateManager){
-            return _g_clientCertificateManager;
-        } else {
-            return _g_clientCertificateManager = new opcua.OPCUACertificateManager({
-                name: "PKI",
-                rootFolder: path.join(folder, "PKI"),
-                automaticallyAcceptUnknownCertificate: autoAccept
-            });
-        }
-    }
-}
 
 let _g_userCertificateManager = null;
-function createUserCertificateManager(autoAccept, folderName) {
-     if (folderName && folderName.length > 0) {
-        if (path.isAbsolute(folderName)) {
-            folder = folderName;
-        }
-        else {
-            folder = config.replace("Config", folderName);
-        }
-        return new opcua.OPCUACertificateManager({
-            name: "PKI",
-            rootFolder: path.join(folder, "PKI"),
-            automaticallyAcceptUnknownCertificate: autoAccept
-        });
-    }
-    else {
-        folder = config;
-        if (_g_userCertificateManager)
-         return _g_userCertificateManager;
-    }
-    return _g_userCertificateManager = new opcua.OPCUACertificateManager({
+function createUserCertificateManager() {
+    if (_g_userCertificateManager) return _g_userCertificateManager;
+
+    _g_userCertificateManager = new opcua.OPCUACertificateManager({
         name: "UserPKI",
-        rootFolder: path.join(config, "UserPKI"),
-        automaticallyAcceptUnknownCertificate: autoAccept
+        rootFolder: path.join(folder, "UserPKI"),
+        automaticallyAcceptUnknownCertificate: true
     });
+    return _g_userCertificateManager;
 }
+
 
 exports.createClientCertificateManager = createClientCertificateManager;
 exports.createServerCertificateManager = createServerCertificateManager;


### PR DESCRIPTION
While investigating various issues on the forum, I found flaw in the way custom certificate PKI folder are handled, which causes random behavior and difficult to trak problem when it comes to deal with issuer (root) certificate handling.


The certificate folder is repeated in each "OPCUAClient '' node , therefore it gets considered for each node, however  an singleton approach to avoid creating multiple certificate managers. In the way it is implemented now, if a OPCUAClient" exists with no FolderName4Pki, and if another OPCUAClient node exist with a FolderName4Pki, and if the first one is initiative first then the FolderName4Pki is not taken into account. 

I suggest that we get rid completely of the FolderName4Pki  and direct the user to the official PKI used by NodeRed-Contrib OPCUA  instead. 

There is rarely (if never ) need for multiple PKI even in a multiple node scenario. 

However this is a breaking change that would require users that are using the FolderName4Pki as they would need to use the standard PKI instead.

the propose changes create 2 PKIs that are common to all clients & servers nodes

~/.config/node-red-opcua-nodejs/PKI for Clients and Servers
~/.config/node-red-opcua-nodejs/UserPKI for X509 Certficate based session.




