### PR TITLE
Added 2nd Outputs for better monitoring of the endpoints, error and their statuses

### DIFF
--- a/opcua/102-opcuaclient.html
+++ b/opcua/102-opcuaclient.html
@@ -42,7 +42,7 @@ limitations under the License.
             name: {value: ""}
         },
         inputs: 1,
-        outputs: 1,
+        outputs: 2,
         align: "right",
         icon: "opcuanodeLogo.png",
         label: function () {

--- a/opcua/102-opcuaclient.html
+++ b/opcua/102-opcuaclient.html
@@ -250,4 +250,8 @@ limitations under the License.
     <p>Read file will read msg.topic nodeId from the server File object, msg.payload will contain buffer</p>
     <p>Write file will write msg.topic nodeId to the server File object, msg.payload will contain buffer OR msg.fileName path to local file to be written to server </p>
 
+
+
+    <p>The second Output is for status monitoring purposes: allowing management of endpoints, their errors and statuses</p>
+    <p>Second Output shall look like this: '{error: {error} , endpoint: {opcuaEndpoint}, status: {currentStatus} }'</p>
 </script>

--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -449,6 +449,8 @@ module.exports = function (RED) {
         text: statusParameter.status,
         endpoint: `${opcuaEndpoint.endpoint}`
       });
+      node.send([null, {error: null , endpoint: `${opcuaEndpoint.endpoint}`, status: currentStatus }])
+
     }
 
     function set_node_status2_to(statusValue, message) {
@@ -460,8 +462,9 @@ module.exports = function (RED) {
         shape: statusParameter.shape,
         text: statusParameter.status + " " + message,
         endpoint: `${opcuaEndpoint.endpoint}`
-
       });
+
+      node.send([null, {error: null , endpoint: `${opcuaEndpoint.endpoint}`, status: currentStatus }])
     }
 
     function set_node_errorstatus_to(statusValue, error) {
@@ -477,6 +480,9 @@ module.exports = function (RED) {
         text: statusParameter.status + " " + error,
         endpoint: `${opcuaEndpoint.endpoint}`
       });
+
+      node.send([null, {error: error , endpoint: `${opcuaEndpoint.endpoint}`, status: currentStatus }])
+
     }
 
     async function connect_opcua_client() {
@@ -735,6 +741,7 @@ module.exports = function (RED) {
       if (!node.action) {
         verbose_warn("Can't work without action (read, write, browse ...)");
         //node.send(msg); // do not send in case of error
+        node.send([null,{error: "Can't work without action (read, write, browse ...)", endpoint: `${opcuaEndpoint.endpoint}`,status: currentStatus}]);
 
         return;
       }
@@ -751,7 +758,7 @@ module.exports = function (RED) {
           reset_opcua_client(connect_opcua_client);
         }
         //node.send(msg); // do not send in case of error
-        node.send([null,{error: "can't work without OPC UA client", endpoint: `${opcuaEndpoint.endpoint}`}]);
+        node.send([null,{error: "can't work without OPC UA client", endpoint: `${opcuaEndpoint.endpoint}`,status: currentStatus}]);
 
         return;
       }
@@ -762,7 +769,7 @@ module.exports = function (RED) {
         reset_opcua_client(connect_opcua_client);
         // node.send(msg); // do not send in case of error
 
-        node.send([null,{error: "terminated OPC UA Session", endpoint: `${opcuaEndpoint.endpoint}`}]);
+        node.send([null,{error: "terminated OPC UA Session", endpoint: `${opcuaEndpoint.endpoint}`,status: currentStatus}]);
 
         return;
       }
@@ -776,7 +783,7 @@ module.exports = function (RED) {
           verbose_warn("can't work without OPC UA NodeId - msg.topic empty");
           // node.send(msg); // do not send in case of error
 
-          node.send([null,{error: "can't work without OPC UA NodeId", endpoint: `${opcuaEndpoint.endpoint}`}]);
+          node.send([null,{error: "can't work without OPC UA NodeId", endpoint: `${opcuaEndpoint.endpoint}`,status: currentStatus}]);
 
           return;
         }
@@ -957,7 +964,7 @@ module.exports = function (RED) {
             msg.payload = ""; 
             node_error(node.name + " failed to read file, nodeId: " + msg.topic + " error: " + err);
             set_node_errorstatus_to("error", "Cannot read file!");
-            node.send([null,{error: node.name + " failed to read file, nodeId: " + msg.topic + " error: " + err, endpoint: `${opcuaEndpoint.endpoint}`}]);
+            node.send([null,{error: node.name + " failed to read file, nodeId: " + msg.topic + " error: " + err, endpoint: `${opcuaEndpoint.endpoint}`,status: currentStatus}]);
 
           }
           /*
@@ -976,7 +983,7 @@ module.exports = function (RED) {
         catch(err) {
           node_error(node.name + " failed to read fileTransfer, nodeId: " + msg.topic + " error: " + err);
           set_node_errorstatus_to("error", err.toString());  
-          node.send([null,{error: node.name + " failed to read fileTransfer, nodeId: " + msg.topic + " error: " + err, endpoint: `${opcuaEndpoint.endpoint}`}]);
+          node.send([null,{error: node.name + " failed to read fileTransfer, nodeId: " + msg.topic + " error: " + err, endpoint: `${opcuaEndpoint.endpoint}`,status: currentStatus}]);
 
         }
       }
@@ -1119,7 +1126,7 @@ module.exports = function (RED) {
           } else {
             set_node_status_to("error: " + result.statusCode.description)
             node.error("Execute method result, error:" + result.statusCode.description);
-            node.send([null,{error: "Execute method result, error:" + result.statusCode.description, endpoint: `${opcuaEndpoint.endpoint}`}]);
+            node.send([null,{error: "Execute method result, error:" + result.statusCode.description, endpoint: `${opcuaEndpoint.endpoint}`,status: currentStatus}]);
 
             return result.statusCode;
           }
@@ -1130,7 +1137,7 @@ module.exports = function (RED) {
         } catch (err) {
           set_node_status_to("Method execution error: " + err.message)
           node.error("Method execution error: " + err.message);
-          node.send([null,{error: "Method execution error: " + err.message, endpoint: `${opcuaEndpoint.endpoint}`}]);
+          node.send([null,{error: "Method execution error: " + err.message, endpoint: `${opcuaEndpoint.endpoint}`,status: currentStatus}]);
 
           return opcua.StatusCodes.BadMethodInvalid;
         }
@@ -1318,11 +1325,11 @@ module.exports = function (RED) {
                     node_error("Bad read: " + (dataValue.statusCode.toString(16)));
                     node_error("Message:" + msg.topic + " dataType:" + msg.datatype);
                     node_error("Data:" + stringify(dataValue));
-                    node.send([null,{error: "Bad read: " + (dataValue.statusCode.toString(16)), endpoint: `${opcuaEndpoint.endpoint}`}]);
+                    node.send([null,{error: "Bad read: " + (dataValue.statusCode.toString(16)), endpoint: `${opcuaEndpoint.endpoint}`,status: currentStatus}]);
 
                   } else {
                     node_error(e.message);
-                     node.send([null,{error: e.message, endpoint: `${opcuaEndpoint.endpoint}`}]);
+                     node.send([null,{error: e.message, endpoint: `${opcuaEndpoint.endpoint}`,status: currentStatus}]);
 
                   }
                 }
@@ -1568,7 +1575,7 @@ module.exports = function (RED) {
                     node_error("Data:" + stringify(dataValue));
                   } else {
                     node_error(e.message);
-                    node.send([null,{error:e.message, endpoint: `${opcuaEndpoint.endpoint}`}]);
+                    node.send([null,{error:e.message, endpoint: `${opcuaEndpoint.endpoint}`,status: currentStatus}]);
                   }
                 }
               }
@@ -1677,7 +1684,7 @@ module.exports = function (RED) {
         set_node_status_to("Session invalid");
         node_error("Session is not active!")
 
-        node.send([null,{error:"Session is not active!", endpoint: `${opcuaEndpoint.endpoint}`}]);
+        node.send([null,{error:"Session is not active!", endpoint: `${opcuaEndpoint.endpoint}`,status: currentStatus}]);
 
       }
     }
@@ -1993,7 +2000,7 @@ module.exports = function (RED) {
             // reset_opcua_client(connect_opcua_client);
             // node.send({ payload: err });
 
-            node.send([{payload: err},{error:`${err}`, endpoint: `${opcuaEndpoint.endpoint}`}]);
+            node.send([{payload: err},{error:`${err}`, endpoint: `${opcuaEndpoint.endpoint}`,status: currentStatus}]);
 
           } else {
             set_node_status_to("active writing");
@@ -2039,7 +2046,7 @@ module.exports = function (RED) {
               // No actual error session created, this case cause connections to server
               // reset_opcua_client(connect_opcua_client);
               // node.send({ payload: err });
-              node.send([{payload: err},{error:`${err}`, endpoint: `${opcuaEndpoint.endpoint}`}]);
+              node.send([{payload: err},{error:`${err}`, endpoint: `${opcuaEndpoint.endpoint}`,status: currentStatus}]);
 
             } else {
               set_node_status_to("active writing");

--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -472,12 +472,13 @@ module.exports = function (RED) {
       node.status({
         fill: statusParameter.fill,
         shape: statusParameter.shape,
-        text: statusParameter.status + " " + error
+        text: statusParameter.status + " " + error,
+        endpoint: `${opcuaEndpoint.name}`
       });
     }
 
     async function connect_opcua_client() {
-      verbose_warn(`connect_opcua_client ${node.client ==null} userIdentity ${JSON.stringify(userIdentity)}`);
+      verbose_warn(`connect_opcua_client`);
 
 
       if (opcuaEndpoint.login === true) { 

--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -445,7 +445,7 @@ module.exports = function (RED) {
         fill: statusParameter.fill,
         shape: statusParameter.shape,
         text: statusParameter.status,
-        endpoint: `${opcuaEndpoint.name}`
+        endpoint: `${opcuaEndpoint.endpoint}`
       });
     }
 
@@ -457,7 +457,7 @@ module.exports = function (RED) {
         fill: statusParameter.fill,
         shape: statusParameter.shape,
         text: statusParameter.status + " " + message,
-        endpoint: `${opcuaEndpoint.name}`
+        endpoint: `${opcuaEndpoint.endpoint}`
 
       });
     }
@@ -473,7 +473,7 @@ module.exports = function (RED) {
         fill: statusParameter.fill,
         shape: statusParameter.shape,
         text: statusParameter.status + " " + error,
-        endpoint: `${opcuaEndpoint.name}`
+        endpoint: `${opcuaEndpoint.endpoint}`
       });
     }
 

--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -208,7 +208,7 @@ module.exports = function (RED) {
     function verbose_warn(logMessage) {
       //if (RED.settings.verbose) {
         // console.warn(chalk.yellow((node.name) ? node.name + ': ' + logMessage : 'OpcUaClientNode: ' + logMessage));
-        node.warn((node.name) ? node.name + ': ' + logMessage : 'OpcUaClientNode: ' + logMessage);
+        node.warn(`${opcuaEndpoint.name}`+ ":" + (node.name) ? node.name + ': ' + logMessage : 'OpcUaClientNode: ' + logMessage);
       //}
     }
 

--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -444,7 +444,8 @@ module.exports = function (RED) {
       node.status({
         fill: statusParameter.fill,
         shape: statusParameter.shape,
-        text: statusParameter.status
+        text: statusParameter.status,
+        endpoint: `${opcuaEndpoint.name}`
       });
     }
 
@@ -455,7 +456,9 @@ module.exports = function (RED) {
       node.status({
         fill: statusParameter.fill,
         shape: statusParameter.shape,
-        text: statusParameter.status + " " + message
+        text: statusParameter.status + " " + message,
+        endpoint: `${opcuaEndpoint.name}`
+
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-opcua",
-  "version": "0.2.318",
+  "version": "0.2.319",
   "description": "A Node-RED node to communicate via OPC UA based on node-opcua library.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I have added a second output for better monitoring of endpoints, errors and their statuses .


Generally what has been done was : 

Output 1 : original output
Output 2: {*error*:  errorString , *endpoint*: opcuaEndpoint, *status*: currentEndpointStatus }

With this we can use the endpoint key to manage which endpoints are having statuses like reconnecting, BadTooManySessions etc. and their error string to work on better error handling.

When there is no error, error will be null but endpoints and statuses are still informed. May refer to examples below

<img width="194" alt="image" src="https://github.com/mikakaraila/node-red-contrib-opcua/assets/29494103/944e214b-6eb7-4cb1-9e8b-be1f389919dd">

<img width="206" alt="image" src="https://github.com/mikakaraila/node-red-contrib-opcua/assets/29494103/20311505-ef1b-46d3-b24f-e17de47da6c9">

