### PR TITLE
Handle errors in subscriptions & gracefully close sessions

### DIFF
--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -692,6 +692,13 @@ module.exports = function (RED) {
         monitoredItems.clear();
       });
 
+      newSubscription.on("error", function (err) {
+        verbose_log("Subscription error on ID: " + newSubscription.subscriptionId + ". " + err);
+        set_node_errorstatus_to("subscription error", err)
+        subscription = null;
+        monitoredItems.clear();
+      })
+
       return newSubscription;
     }
 

--- a/opcua/opcua-basics.js
+++ b/opcua/opcua-basics.js
@@ -302,6 +302,7 @@ module.exports.get_node_status = function (statusValue) {
         case "invalid endpoint":
         case "disconnected":
         case "connection error":
+        case "subscription error":
         case "node error":
         case "terminated":
         case "no client":


### PR DESCRIPTION
In this PR, two enhancements are introduced.

### Subscription error handling (`commit  2b75755...`)
If the subscription limit of the OPC-UA was reached, an uncaught error would be raised, stopping Node-RED completely. Then, Node-RED would fail to start again (if set to restart on errors), since the amount of subscriptions is likely the same. Now, whenever there's an error on the subscription, it will be reported but Node-RED will continue working. Example of the new handling working:

![TooManySubscriptions example](https://github.com/mikakaraila/node-red-contrib-opcua/assets/103569850/639591d7-4e6a-4070-936d-4f30f768d4ff)

### Gracefully close sessions (`commit  809f458...`)
When Node-RED was stopped, the `node.on("close")` handler wasn't waiting for all the flows to finish their tasks before closing Node-RED. If more than one flow had active OPC-UA sessions, some of them could be left open on the server. Now, the `session.close()` is awaited and the `done()` function is called in the end of the `node.on("close")` handler.