### PR TITLE
Use topic browsename when topic displayname is not set

### DIFF
--- a/opcua/104-opcuaserver.js
+++ b/opcua/104-opcuaserver.js
@@ -1085,7 +1085,7 @@
                                 nodeId: name,
                                 browseName: browseNameTopic || browseName,
                                 description: description,
-                                displayName: displayName || browseName,
+                                displayName: displayName || browseNameTopic || browseName,
                                 dataType: opcua.coerceNodeId(typeId), // "ExtensionObject", // "StructureDefinition", // typeId,
                                 minimumSamplingInterval: 500,
                                 valueRank,
@@ -1124,7 +1124,7 @@
                             accessRestrictions: opcua.AccessRestrictionsFlag.None, // TODO from msg
                             browseName: browseNameTopic || browseName, // or displayName
                             description: description,
-                            displayName: displayName || browseName,
+                            displayName: displayName || browseNameTopic || browseName,
                             dataType: datatype, // opcuaDataType,
                             minimumSamplingInterval: 500,
                             valueRank,


### PR DESCRIPTION
When the displayName is not set in the topic the old browseName is used
I changed it to use the browsename set in the topic (when available). If not it takes the old (internal) browseName.
#685 