### PR TITLE
Initial support for Variant Array

### DIFF
--- a/opcua/opcua-basics.js
+++ b/opcua/opcua-basics.js
@@ -182,6 +182,7 @@ ALIASES for Basic types:
 <Alias Alias="LocalizedText">i=21</Alias>
 <Alias Alias="StatusCode">i=19</Alias>
 <Alias Alias="Structure">i=22</Alias>
+<Alias Alias="Variant">i=24</Alias>
 <Alias Alias="Number">i=26</Alias>
 <Alias Alias="Integer">i=27</Alias>
 <Alias Alias="UInteger">i=28</Alias>
@@ -219,6 +220,7 @@ module.exports.convertToString = function(inType) {
     if (inType === "ns=0;i=20") return "QualifiedName";
     if (inType === "ns=0;i=21") return "LocalizedText";
     if (inType === "ns=0;i=22") return "Structure";
+    if (inType === "ns=0;i=24") return "Variant";
     if (inType === "ns=0;i=26") return "Number";
     if (inType === "ns=0;i=27") return "Integer";
     if (inType === "ns=0;i=28") return "UInteger";
@@ -547,6 +549,11 @@ function getArrayValues(datatype, items) {
         uaArray.values = new Array(items);
         // console.log("ITEMS:" + items.toString());
     }
+    if (datatype.indexOf("Variant") >= 0) {
+        uaArray.uaType = opcua.DataType.Variant;
+        uaArray.values = new Array(items);
+        // console.log("ITEMS:" + items.toString());
+    }
     if (datatype.indexOf("ExtensionObject") >= 0) {
         uaArray.uaType = opcua.DataType.ExtensionObject;
         uaArray.values = items;
@@ -569,7 +576,7 @@ function getArrayValues(datatype, items) {
                 uaArray.values[index] = true;
             }
         }
-        else if (uaArray.uaType === opcua.DataType.String || uaArray.uaType === opcua.DataType.ExtensionObject) {
+        else if (uaArray.uaType === opcua.DataType.String || uaArray.uaType === opcua.DataType.ExtensionObject || uaArray.uaType === opcua.DataType.Variant) {
             uaArray.values[index] = item;
         }
         else {
@@ -652,6 +659,9 @@ function getArrayType(datatype) {
     }
     if (datatype.indexOf("String") >= 0) {
         return opcua.DataType.String;
+    }
+    if (datatype.indexOf("Variant") >= 0) {
+        return opcua.DataType.Variant;
     }
     if (datatype.indexOf("ExtensionObject") >= 0) {
         return opcua.DataType.ExtensionObject;
@@ -954,6 +964,7 @@ module.exports.build_new_dataValue = function (datatype, value) {
     if (m > 0) {
         var uaType = getArrayType(datatype);
         var arrayValues;
+        //console.log("ARRAY: " + JSON.stringify({"uaType":uaType,"value":value}));
         if (value && value.value) {
             arrayValues = getArrayValues(datatype, Object.values(value.value));
         }


### PR DESCRIPTION
Initial support for Variant Array, partially fix #680

Injecting this into a write opca-client node:

```json
{
   "_msgid":"5f93bc6d8a31233e",
   "payload":{
      "value":[
         {
            "dataType":"Variant",
            "arrayType":"Array",
            "value":[
               {
                  "dataType":"UInt16",
                  "arrayType":"Scalar",
                  "value":1
               },
               {
                  "dataType":"UInt32",
                  "arrayType":"Scalar",
                  "value":10
               },
               {
                  "dataType":"String",
                  "arrayType":"Scalar",
                  "value":"Order Des"
               },
               {
                  "dataType":"String",
                  "arrayType":"Scalar",
                  "value":"Program Des"
               },
               {
                  "dataType":"String",
                  "arrayType":"Scalar",
                  "value":"Mould Name"
               },
               {
                  "dataType":"String",
                  "arrayType":"Scalar",
                  "value":"Material Des"
               },
               {
                  "dataType":"String",
                  "arrayType":"Scalar",
                  "value":"07/05/2024"
               },
               {
                  "dataType":"String",
                  "arrayType":"Scalar",
                  "value":"Item"
               },
               {
                  "dataType":"String",
                  "arrayType":"Scalar",
                  "value":"Item Description"
               }
            ]
         },
         {
            "dataType":"Variant",
            "arrayType":"Array",
            "value":[
               {
                  "dataType":"UInt16",
                  "arrayType":"Scalar",
                  "value":2
               },
               {
                  "dataType":"UInt32",
                  "arrayType":"Scalar",
                  "value":20
               },
               {
                  "dataType":"String",
                  "arrayType":"Scalar",
                  "value":"Order Des 2"
               },
               {
                  "dataType":"String",
                  "arrayType":"Scalar",
                  "value":"Program Des 2"
               },
               {
                  "dataType":"String",
                  "arrayType":"Scalar",
                  "value":"Mould Name 2"
               },
               {
                  "dataType":"String",
                  "arrayType":"Scalar",
                  "value":"Material Des 2"
               },
               {
                  "dataType":"String",
                  "arrayType":"Scalar",
                  "value":"07/05/2024"
               },
               {
                  "dataType":"String",
                  "arrayType":"Scalar",
                  "value":"Item2"
               },
               {
                  "dataType":"String",
                  "arrayType":"Scalar",
                  "value":"Item Description 2"
               }
            ]
         }
      ]
   },
   "topic":"ns=2;i=115682",
   "datatype":"VariantArray",
   "browseName":"f078-Value"
}
```

is possible to see an almost correct object passed to node-opca component:

```
8 May 11:14:57 - [debug] [OpcUa-Client:ARB-25M] Action on input: write Item from Topic: ns=2;i=115682 session Id: ns=3;i=2500861593
8 May 11:14:57 - [debug] [OpcUa-Client:ARB-25M] { /*BrowsePath*/
 startingNode                  /*  NodeId                                    */: ns=2;i=115682
 relativePath                  /*  RelativePath                              */: {
   elements                    /*  RelativePathElement                   []  */: [
     { /* 0 - RelativePathElement*/
       referenceTypeId         /*  NodeId                                    */: Aggregates (ns=0;i=44)
       isInverse               /*  Boolean                                   */: false
       includeSubtypes         /*  Boolean                                   */: true
       targetName              /*  QualifiedName                             */: <null>
     }
   ]
 }
};
8 May 11:14:57 - [debug] [OpcUa-Client:ARB-25M] NodeId= ns=2;i=115682 type=VariantArray
8 May 11:14:57 - [debug] [OpcUa-Client:ARB-25M] VALUE TO WRITE: {"nodeId":"ns=2;i=115682","attributeId":13,"value":{"value":{"dataType":"Variant","arrayType":"Array","value":[{"dataType":"Variant","arrayType":"Array","value":[{"dataType":"UInt16","arrayType":"Scalar","value":1},{"dataType":"UInt32","arrayType":"Scalar","value":10},{"dataType":"String","arrayType":"Scalar","value":"Order Des"},{"dataType":"String","arrayType":"Scalar","value":"Program Des"},{"dataType":"String","arrayType":"Scalar","value":"Mould Name"},{"dataType":"String","arrayType":"Scalar","value":"Material Des"},{"dataType":"String","arrayType":"Scalar","value":"07/05/2024"},{"dataType":"String","arrayType":"Scalar","value":"Item"},{"dataType":"String","arrayType":"Scalar","value":"Item Description"}]},{"dataType":"Variant","arrayType":"Array","value":[{"dataType":"UInt16","arrayType":"Scalar","value":2},{"dataType":"UInt32","arrayType":"Scalar","value":20},{"dataType":"String","arrayType":"Scalar","value":"Order Des 2"},{"dataType":"String","arrayType":"Scalar","value":"Program Des 2"},{"dataType":"String","arrayType":"Scalar","value":"Mould Name 2"},{"dataType":"String","arrayType":"Scalar","value":"Material Des 2"},{"dataType":"String","arrayType":"Scalar","value":"07/05/2024"},{"dataType":"String","arrayType":"Scalar","value":"Item2"},{"dataType":"String","arrayType":"Scalar","value":"Item Description 2"}]}]},"statusCode":{"value":0},"sourcePicoseconds":0,"serverPicoseconds":0}}
8 May 11:14:57 - [debug] [OpcUa-Client:ARB-25M] Client status: writing
8 May 11:14:57 - [debug] [OpcUa-Client:ARB-25M] Client status: value written
8 May 11:14:57 - [debug] [OpcUa-Client:ARB-25M] Value written! Result:2155085824 The value supplied for the attribute is not of the same type as the attribute's value.
ARB-25M: StatusCode: BadTypeMismatch (0x80740000) The value supplied for the attribute is not of the same type as the attribute's value.
8 May 11:14:57 - [warn] [OpcUa-Client:ARB-25M] StatusCode: BadTypeMismatch (0x80740000) The value supplied for the attribute is not of the same type as the attribute's value.
8 May 11:14:57 - [debug] [OpcUa-Client:ARB-25M] Client status: error
```

But from Wireshark still showing a partial empty  write request:

![image](https://github.com/mikakaraila/node-red-contrib-opcua/assets/13371954/158a77f4-5e0d-48f1-8975-beb1a34fbf52)

