### PR TITLE
Fix default binary encoding not found for Variant

### DIFF
--- a/opcua/107-opcuamethod.js
+++ b/opcua/107-opcuamethod.js
@@ -355,14 +355,10 @@ module.exports = function (RED) {
             if (arg.dataType === "ExtensionObject") {
               var extensionobject = null;
               if (arg.typeid) {
-                extensionobject = await node.session.constructExtensionObject(opcua.coerceNodeId(arg.typeid), {}); // TODO make while loop to enable await
+                extensionobject = await node.session.constructExtensionObject(opcua.coerceNodeId(arg.typeid), arg.value); // TODO make while loop to enable await
               }
               verbose_log("ExtensionObject=" + stringify(extensionobject));
-              Object.assign(extensionobject, arg.value);
-              arg.value = new opcua.Variant({
-                dataType: opcua.DataType.ExtensionObject,
-                value: extensionobject
-              });
+              arg.value = extensionobject;
             }
             i++;
           }


### PR DESCRIPTION
- The constructExtensionObject can assign the incoming data to the new extensionobject variable without using the Object.assign method
- By using the Variant class on arg.value, the method throw exception `Cannot find encodingDefaultBinary for this object : Variant`.
To solve this just pass the ExtensionObject directly