### PR TITLE
Added deletion of items from previous calls in browse node

### DIFF
--- a/opcua/103-opcuabrowser.js
+++ b/opcua/103-opcuabrowser.js
@@ -161,7 +161,9 @@ module.exports = function (RED) {
 
         node.on("input", function (msg) {
             node.debug("input browser");
-            
+
+            node.items = [];
+         
             let nodeToBrowse = msg.topic ? msg.topic : node.topic;
             if(!nodeToBrowse) nodeToBrowse = objectsFolderNodeId;
             


### PR DESCRIPTION
The list of items is not being cleared in the current version. When triggered repeatedly, the previous items are returned again. The reason for this behavior is not apparent to me. I have added a deletion of the items array in this pull request.