### PR TITLE
Added support for UInt64 in server node and client write

### DIFF
--- a/opcua/104-opcuaserver.js
+++ b/opcua/104-opcuaserver.js
@@ -209,6 +209,9 @@
             if (methodArgType === "UInt32") {
                 return opcua.DataType.UInt32;
             }
+            if (methodArgType === "UInt64") {
+                return opcua.DataType.UInt64;
+            }
             if (methodArgType === "Int16") {
                 return opcua.DataType.Int32;
             }
@@ -1023,6 +1026,9 @@
                         }
                         if (datatype == "UInt32") {
                             opcuaDataType = opcua.DataType.UInt32;
+                        }
+                        if (datatype == "UInt64") {
+                            opcuaDataType = opcua.DataType.UInt64;
                         }
                         if (datatype == "UInt16") {
                             opcuaDataType = opcua.DataType.UInt16;


### PR DESCRIPTION
Added UInt64 as an accepted type to the opcua server node, and added handling for the different formats of uint64 mentioned in #728 102-opcuaclient.js. First time contributing to an open source repo, so let me know if there are anything I should be doing differently.