### PR TITLE
Client Node fix for empty password

### DIFF
--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -135,7 +135,7 @@ module.exports = function (RED) {
       userIdentity = {
         type: opcua.UserTokenType.UserName,
         userName: opcuaEndpoint.credentials.user.toString(),
-        password: opcuaEndpoint.credentials.password.toString()
+        password: opcuaEndpoint.credentials.password ? opcuaEndpoint.credentials.password.toString() : ""
       };
       verbose_log(chalk.green("Using UserName & password: ") + chalk.cyan(JSON.stringify(userIdentity)));
     }


### PR DESCRIPTION
If password is left blank, Client Node throws an error. This update will attempt to use an empty string as a password if the password field is left blank

Files affected:
- opcua/102-opcuaclient.js