### PR TITLE
client: allow setting applicationName and applicationUri

### DIFF
--- a/opcua/102-opcuaclient.html
+++ b/opcua/102-opcuaclient.html
@@ -40,7 +40,9 @@ limitations under the License.
             sendBufferSize: {value: 8192, required: false},
             setstatusandtime: {value: false, required: true},
             keepsessionalive: {value: false, required: true},
-            name: {value: ""}
+            name: {value: ""},
+            applicationName: {value: "", required: false},
+            applicationUri: {value: "", required: false}
         },
         inputs: 1,
         outputs: 3,
@@ -151,6 +153,14 @@ limitations under the License.
 	<div class="form-row">
         <label for="node-input-path"><i class="icon-tasks"></i> Local private key file, fixed path</label>
         <input type="text" id="node-input-localkeyfile" placeholder="Path is not used anymore! Example: private_key.pem">
+    </div>
+    <div class="form-row">
+        <label for="node-input-applicationName"><i class="icon-tasks"></i> Application Name</label>
+        <input type="text" id="node-input-applicationName" placeholder="NodeOPCUAClient">
+    </div>
+    <div class="form-row">
+        <label for="node-input-applicationUri"><i class="icon-tasks"></i> Application URI</label>
+        <input type="text" id="node-input-applicationUri" placeholder="urn:mycompany:NodeOPCUAClient">
     </div>
     <div class="form-row">
         <label for="node-input-useTransport" style="width:72%;"><i class="icon-tasks"></i> Use transport settings</label>

--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -58,6 +58,8 @@ module.exports = function (RED) {
     this.sendBufferSize = n.sendBufferSize;
     this.setstatusandtime = n.setstatusandtime;
     this.keepsessionalive = n.keepsessionalive;
+    this.applicationName = n.applicationName;
+    this.applicationUri = n.applicationUri;
     let node = this;
     let opcuaEndpoint = RED.nodes.getNode(n.endpoint); // Use as global for the node
     let userIdentity = { type: opcua.UserTokenType.Anonymous }; // Initialize with Anonymous
@@ -89,6 +91,8 @@ module.exports = function (RED) {
         node_error("Local private key file not found: " + keyfile)
       }
     }
+    if (node.applicationName) connectionOption.applicationName = node.applicationName;
+    if (node.applicationUri) connectionOption.applicationUri = node.applicationUri;
     // Moved needed options to client create
     connectionOption.requestedSessionTimeout = opcuaBasics.calc_milliseconds_by_time_and_unit(300, "s");
     // DO NOT USE must be NodeOPCUA-Client !! connectionOption.applicationName = node.name; // Application name
@@ -307,8 +311,10 @@ module.exports = function (RED) {
           clientName: node.name, // Fix for #664 sessionName
           keepSessionAlive: node.keepsessionalive,
           requestedSessionTimeout: 60000 * 5, // 5min, default 1min
-          automaticallyAcceptUnknownCertificate: true
+          automaticallyAcceptUnknownCertificate: true,
           // transportSettings: transportSettings // Some 
+          applicationName: connectionOption.applicationName,
+          applicationUri: connectionOption.applicationUri
       };
       try {
         // Use empty 0.0.0.0 address as "no client" initial value


### PR DESCRIPTION
This enables better support for user-provided certificates, where the applicationUri is expected to match the certificate's subjectAltName field.

Closes #823 