### PR TITLE
Sometimes JSON.stringify can cause circular structure error when printing whole msg object

### DIFF
--- a/opcua/104-opcuaserver.js
+++ b/opcua/104-opcuaserver.js
@@ -588,7 +588,11 @@
 
         //######################################################################################
         node.on("input", function (msg) {
-            verbose_log(JSON.stringify(msg));
+            try {
+                verbose_log(JSON.stringify(msg));
+            } catch (e) {
+                verbose_log(JSON.stringify(msg.payload));
+            }
             if (!node.server || !initialized) {
                 node_error("Server is not running");
                 return false;


### PR DESCRIPTION
Sometimes the JSON.stringify(msg) can cause circular structure error.
Especially when using http-node as originating node since it also sends msg.req and msg.res.
<img width="817" height="138" alt="image" src="https://github.com/user-attachments/assets/d482f4bf-0932-4ddf-abc2-c5f9453b8880" />

Solved by try catching verbose log:
```
node.on("input", function (msg) {
            try {
                verbose_log(JSON.stringify(msg));
            } catch (e) {
                verbose_log(JSON.stringify(msg.payload));
            }
```