### PR TITLE
Logging the options obj sometimes prevents client creation

### DIFF
--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -338,9 +338,9 @@ module.exports = function (RED) {
         verbose_log(chalk.yellow("Keep session alive: ") + chalk.cyan(node.keepsessionalive));
         if (node.useTransport === true) {
           options["transportSettings"] = JSON.parse(JSON.stringify(connectionOption.transportSettings));
-          verbose_log(chalk.red("NOTE: Using transport settings: " + chalk.cyan(JSON.stringify(options))));
+          verbose_log(chalk.red("NOTE: Using transport settings: " + chalk.cyan(stringify(options))));
         }
-        verbose_log(chalk.green("1) CREATE CLIENT: ") + chalk.cyan(JSON.stringify(options)));
+        verbose_log(chalk.green("1) CREATE CLIENT: ") + chalk.cyan(stringify(options)));
         node.client = opcua.OPCUAClient.create(options);
         node.client.on("connection_reestablished", reestablish);
         node.client.on("backoff", backoff);


### PR DESCRIPTION
Previously `JSON.stringify` was used to log options, which fired an error inside a try block of the function `create_opcua_client`. This error prevents the creation of the client and generates the following log:

<img width="1206" height="206" alt="image" src="https://github.com/user-attachments/assets/e3b80e46-aee0-4aa8-8497-d7bf4436a732" />

`JSON.stringify` was changed to flatted's `stringify` function, which fixes the problem and enables the options to be logged:

<img width="1080" height="115" alt="image" src="https://github.com/user-attachments/assets/65a46d6c-1fff-4db8-a6f5-df11ab2ef20e" />

This error occurs intermittently, due to a circular reference being created in the options obj at some point.