### PR TITLE
Fix: Support multiple array input formats for OPC UA server writes

### DIFF
--- a/opcua/opcua-basics.js
+++ b/opcua/opcua-basics.js
@@ -1034,7 +1034,7 @@ module.exports.build_new_dataValue = function (datatype, value) {
                 arrayValues = getArrayValues(datatype, Array.from(raw));
             }
             else {
-                arrayValues = getArrayValues(datatype, Object.values(raw));
+                arrayValues = getArrayValues(datatype, raw);
             }
         }
         else if (Array.isArray(value)) {
@@ -1045,7 +1045,7 @@ module.exports.build_new_dataValue = function (datatype, value) {
         }
         else if (typeof value === "string") {
             var items = value.split(",");
-            arrayValues = getArrayValues(datatype, Object.values(items));
+            arrayValues = getArrayValues(datatype, items);
         }
         else {
             arrayValues = getArrayValues(datatype, [value]);


### PR DESCRIPTION
## 📝 Description

### Problem
When writing array values to a server using the OpcUa-Item node, the code failed to handle various input formats correctly. Specifically:
- array detection logic used an unsafe bitwise OR operation (datatype?.indexOf("Array") | -1) that could produce incorrect results
- only basic array formats are supported, causing failures when I passed TypedArrays (Float32Array, Uint8Array, etc.) or other
- no fallback handling for edge cases like scalar values or nested value objects

This resulted in write failures when attempted to write arrays in formats other than plain JS arrays.

### Solution
Enhanced array value handling in build_new_value_by_datatype and build_new_dataValue functions:
1. Fixed array detection: Replaced bitwise OR with nullish coalescing operator ((datatype ?? "").indexOf("Array"))
2. Added TypedArray support: Detect and convert TypedArrays using ArrayBuffer.isView() and Array.from()
3. Multiple input format support: Handle arrays, TypedArrays, strings (comma-separated), nested value objects, and scalar values
4. Improved robustness: Added explicit type checking and proper fallback logic for all input scenarios

The fix should handle that array writes work correctly regardless of how the user provides the array data.

## 🔗 Related Issues
[cannot get extension object or array to work #764](https://github.com/mikakaraila/node-red-contrib-opcua/issues/764)
[Writing array... always BadTypeMismatch with current version #831](https://github.com/mikakaraila/node-red-contrib-opcua/issues/831)
maybe more?

## ✅ Checklist

Complete the below before requesting a review:

- [x] I have reviewed my own changes