### PR TITLE
chore: Update 102-opcuaclient.html, fix msg.topic typo

### DIFF
--- a/opcua/102-opcuaclient.html
+++ b/opcua/102-opcuaclient.html
@@ -260,7 +260,7 @@ limitations under the License.
     <p>Browse will lookup address space from the injected msg.topic (nodeId)</p>
     <p> if msg.collect === true then result will be collected into one msg. msg.payload will be array of items</p>
     <p> msg.payload.range = "2:4" and FloatArray or any Array datatype then indexes from 2 to 4 will be used to read or write depending on action</p>
-    <p>History will read mdg.topic = nodeId and msg.aggregate = "raw", historical values or aggregate "min" or "max" or "ave" or "interpolative"</p>
+    <p>History will read msg.topic = nodeId and msg.aggregate = "raw", historical values or aggregate "min" or "max" or "ave" or "interpolative"</p>
     <p> Other needed parameters start time and end time:
     <p> msg.start if not given 1 hour from now will be used</p>
     <p> msg.end   if not given default value is now</p>


### PR DESCRIPTION
Simply typo fix in the help description of the opc-ua client node.