### PR TITLE
Fix null crash in getBrowseName when event field name is missing

### DIFF
--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -193,7 +193,7 @@ module.exports = function (RED) {
         nodeId
       });
       if (dataValue.statusCode.isGood()) {
-        const browseName = dataValue.value.value.name;
+        const browseName = dataValue?.value?.value?.name || "UnknownEvent";
         return browseName;
       } else {
         return "???";


### PR DESCRIPTION
When subscribing to OPC UA events, my client crashed with:

```
TypeError: Cannot read properties of null (reading 'name')
at getBrowseName (102-opcuaclient.js:196:50)
```

This happens because `getBrowseName` accesses `dataValue.value.value.name` directly. I'm not sure whether it's the server's responsibility to always provide a complete event structure, but in my case the server sent events where this field was missing, causing an unhandled TypeError that took down the entire client node.

## Suggested fix

Added optional chaining with a fallback value:

```js
// Before
const browseName = dataValue.value.value.name;

// After
const browseName = dataValue?.value?.value?.name || "UnknownEvent";
```

Tested on
node-red-contrib-opcua 0.2.349
OPC UA server: Siemens PCS7 UA Server
Security: Basic256Sha256, SignAndEncrypt
Events with missing/null fields are now handled gracefully instead of crashing

