### PR TITLE
Fix stale value returned by addVariable/bindVariables timestamped_get (#855)

### DIFF
--- a/opcua/104-opcuaserver.js
+++ b/opcua/104-opcuaserver.js
@@ -1264,10 +1264,24 @@
                             minimumSamplingInterval: 500,
                             valueRank,
                             arrayDimensions: dimensions,
-                            value: // new opcua.Variant({arrayType, dataType: opcuaDataType, value: variables[variableId]}) 
+                            value: // new opcua.Variant({arrayType, dataType: opcuaDataType, value: variables[variableId]})
                             {
+                                // Build a fresh DataValue from the live variables[] dictionary on every read.
+                                // The previous implementation returned a closed-over `newValue` captured at variable
+                                // creation, which meant scalar variables were frozen at their initial value despite
+                                // the `set` callback updating `variables[variableId]`. See issue #855.
                                 timestamped_get: () => {
-                                    return newValue;
+                                    const liveVariant = (valueRank >= 2)
+                                        ? new opcua.Variant({ arrayType, dimensions, dataType: opcuaDataType, value: variables[variableId] })
+                                        : new opcua.Variant({ arrayType, dataType: opcuaDataType, value: variables[variableId] });
+                                    return new DataValue({
+                                        serverPicoseconds: 0,
+                                        serverTimestamp: new Date(),
+                                        sourcePicoseconds: 0,
+                                        sourceTimestamp: variablesTs[variableId] || ts,
+                                        statusCode: variablesStatus[variableId] || st,
+                                        value: liveVariant
+                                    });
                                 },
                                 set: function (variant) {
                                     verbose_log(chalk.yellow("Server set new variable value : ") + chalk.cyan(variables[variableId]) + chalk.yellow(" browseName: ") + chalk.cyan(ns) + ":" + chalk.cyan(browseName) + chalk.yellow(" new: ") + chalk.cyan(stringify(variant)));
@@ -1686,8 +1700,20 @@
                             });
 
                             var options = {
+                                // Build a fresh DataValue from the live variables[] dictionary on every read,
+                                // for the same reason as in addVariable above (issue #855).
                                 timestamped_get: () => {
-                                    return newValue;
+                                    return new DataValue({
+                                        serverPicoseconds: 0,
+                                        serverTimestamp: new Date(),
+                                        sourcePicoseconds: 0,
+                                        sourceTimestamp: variablesTs[variableId] || ts,
+                                        statusCode: variablesStatus[variableId] || st,
+                                        value: new opcua.Variant({
+                                            dataType: opcuaBasics.convertToString(variable.dataType.toString()),
+                                            value: variables[variableId]
+                                        })
+                                    });
                                 },
                                 set: (variant) => {
                                     // Store value


### PR DESCRIPTION
Closes #855.

## Problem

In `opcua/104-opcuaserver.js`, the value getter on a dynamically-added variable returns a closed-over `DataValue` captured at variable-creation time. The corresponding `set` callback updates `variables[variableId]`, but `timestamped_get` always returns the **initial** `newValue` object.

For scalar types (Float, Int*, Boolean, String, etc.), the `Variant` copies the primitive value at construction time, so `newValue` is permanently frozen at `0` / `""` / `false`. Symptoms:

- Writes via `payload.messageType = "Variable"` or via `OpcUa-Client` (`write` / `writemultiple`) return `Good`, the `set` callback fires, but every subsequent read returns the initial value.
- Subscribers stay on `keepalive` and never transition to `active subscribed` because no value-change events ever fire.
- External OPC UA clients (UaExpert, python-opcua, etc.) read default values regardless of what's been written.

This is exactly what @intmech diagnosed in #855.

The same pattern is present in two places:

| | Location | Lines |
|---|---|---|
| 1 | `case "addVariable":` — variable created with custom value binding | ~1269 |
| 2 | `case "bindVariables":` → `bindCallbacks` — variable bound with custom value binding | ~1689 |

Both are fixed in this PR.

## Fix

Rebuild the `DataValue` from the live `variables[variableId]` on every `timestamped_get` call, using the live source-timestamp / status already maintained in `variablesTs` / `variablesStatus` (with the locally-captured `ts` / `st` as a fallback). All necessary variables are already in scope at both call sites; the `arrayType` / `dimensions` / `opcuaDataType` path is preserved for `valueRank >= 2` in the `addVariable` case.

Diff: **+29 / −3** lines in one file. No public API changes; behaviour for `set`, write paths, output emits, and `bindMethod` / other commands is unchanged.

## Verification

Tested locally on a Linux Node-RED 4.1.10 instance running `node-red-contrib-opcua` v0.2.351:

**Before**

- `payload.messageType: "Variable"` writes → `Good` but value stays at default
- `node.set_value(42, ua.VariantType.Int32)` via python-opcua → no error, value stays at 0
- Subscription status sticks on `keepalive`, never `active subscribed`

**After**

- The simulator's per-tick dispatcher writes (using `messageType: "Variable"`) propagate to subscribers
- External `python-opcua` reads return the current value
- An `OpcUa-Client` (subscribe) wired to the same server transitions to `active subscribed` and emits a value-change event for every update
- Existing flows continue to work unchanged

Tested all three data-type families used by the local flow: `Int32`, `Boolean`, `String`. No regressions in the simulator's existing manual-override / pause UI flow.

## Notes

- Per-read DataValue allocation is intentional and matches node-opcua patterns elsewhere — the cost is negligible compared to the OPC UA stack overhead, and it cleanly avoids the closure-capture trap.
- I didn't touch the `set` callback's existing `node.send` behaviour — the server still emits an output message for every write, as before.
- Happy to add a unit test if you have a place for one (didn't spot a test directory exercising the server node).