### PR TITLE
fix: clone msg per item in readmultiple to keep distinct topics #882

### DIFF
--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -1513,13 +1513,16 @@ module.exports = function (RED) {
 
                     // Use nodeId in topic, arrays are same length
                     // Output pin 1 for each value by value
-                    // verbose_log("Output pin1, topic: " + JSON.stringify(multipleItems[i]) + " payload: " + value);
-                    msg.topic = multipleItems[i].nodeId.toString();
-                    msg.payload = value;
-                    msg.statusCode = dataValue.statusCode;
-                    msg.serverTimestamp = serverTs;
-                    msg.sourceTimestamp = sourceTs;
-                    node.send([msg, null, null]);//node.send([{topic: multipleItems[i], payload: value, statusCode: dataValue.statusCode, serverTimestamp: serverTs, sourceTimestamp: sourceTs}, null, null]);
+                    // Clone msg per item: Node-RED passes the first node.send()
+                    // by reference, so mutating the shared msg in this loop
+                    // corrupts the per-item topic of already-sent messages.
+                    let outMsg = RED.util.cloneMessage(msg);
+                    outMsg.topic = multipleItems[i].nodeId.toString();
+                    outMsg.payload = value;
+                    outMsg.statusCode = dataValue.statusCode;
+                    outMsg.serverTimestamp = serverTs;
+                    outMsg.sourceTimestamp = sourceTs;
+                    node.send([outMsg, null, null]);
                   } catch (e) {
                     if (dataValue != null) {
                       node_error("Bad read, statusCode: " + (dataValue.statusCode.toString(16)));


### PR DESCRIPTION
## Problem

Before #874, the `readmultiple` action built a brand-new message object for each value it sent. That dropped the original message's identity (`_msgid`) and its link-call metadata, which breaks `link call` flows. #874 fixed this by reusing the incoming `msg` (updating its fields) instead of creating a new one, so that context is preserved.

But `readmultiple` emits one message **per nodeId**. Reusing a single shared `msg` across those `node.send()` calls is where it breaks: Node-RED does not deep-clone on every send, so downstream nodes alias the same object — later iterations overwrite the topic/payload of messages already sent. Any node keyed
on `msg.topic` (e.g. collecting N distinct nodeIds) receives duplicated/last-value topics and breaks **silently** — no error, just data loss.

## Fix

Clone the message per item with `RED.util.cloneMessage(msg)`:

```js
// Before (0.2.351) — shared msg mutated in the loop
msg.topic = multipleItems[i].nodeId.toString();
msg.payload = value;
msg.statusCode = dataValue.statusCode;
node.send([msg, null, null]);

// After — independent message per item
let outMsg = RED.util.cloneMessage(msg);
outMsg.topic = multipleItems[i].nodeId.toString();
outMsg.payload = value;
outMsg.statusCode = dataValue.statusCode;
node.send([outMsg, null, null]);
```

This keeps #874's goal (the clone copies `_msgid` + all props, so context is preserved) while giving each emitted message an independent object so topics stay distinct.

Scope is minimal: only the per-item loop is cloned. The single-send paths (ALL branch, output 3) keep #874 `msg` reuse untouched.

## Testing

Bisected: works in 0.2.348 (`b75aa27`), broken in 0.2.351 (`a59ddba`).

End-to-end on Node-RED 4.1.8 — `readmultiple` of 8 nodeIds wired to a function that collects 8 distinct `msg.topic` keys before emitting:

| Setup | Result |
|---|---|
| vanilla 0.2.351 | collector never fires — 0 messages through |
| 0.2.351 + this patch | all 8 distinct topics arrive, collector fires |
| 0.2.348 (pre-regression) | identical to patched behaviour |

**Steps to reproduce:**

1. Point an `OpcUa-Client` (action: `readmultiple`) at any server, reading ≥2 nodeIds
  (`inject → function building the readmultiple payload → client`).
2. Wire output 1 to a Function node (the "collector") that waits for N distinct topics:
  ```js
  const buf = context.get('buf') || {};
  buf[msg.topic] = msg.payload;
  context.set('buf', buf);
  if (Object.keys(buf).length < 2) return null;   // wait for both nodeIds
  context.set('buf', {});
  return msg;                                      // never reached on 0.2.351
  ```
3. Wire the collector to a Debug node, deploy, fire the inject.
4. 0.2.348: Debug fires once per poll. 0.2.351: Debug never fires — buf 
only ever holds 1 key because every message carries the same (last) topic.

## Related

- Fixes #882 
- Follow-up to #874 