### PR TITLE
Prevent read timeout in event handling from crashing Node-RED

### DIFF
--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -188,14 +188,19 @@ module.exports = function (RED) {
     }
 
     async function getBrowseName(_session, nodeId) {
-      const dataValue = await _session.read({
-        attributeId: AttributeIds.BrowseName,
-        nodeId
-      });
-      if (dataValue.statusCode.isGood()) {
-        const browseName = dataValue?.value?.value?.name || "UnknownEvent";
-        return browseName;
-      } else {
+      try {
+        const dataValue = await _session.read({
+          attributeId: AttributeIds.BrowseName,
+          nodeId
+        });
+        if (dataValue.statusCode.isGood()) {
+          const browseName = dataValue?.value?.value?.name || "UnknownEvent";
+          return browseName;
+        } else {
+          return "???";
+        }
+      } catch (err) {
+        verbose_log(chalk.red("getBrowseName read failed: ") + chalk.cyan(err.message));
         return "???";
       }
     }
@@ -269,7 +274,11 @@ module.exports = function (RED) {
     }
 
     let eventQueue = new async.queue(function (task, callback) {
-      __dumpEvent(task.node, task.session, task.fields, task.eventFields, callback);
+      __dumpEvent(task.node, task.session, task.fields, task.eventFields, callback)
+        .catch(function (err) {
+          node_error(err);
+          callback();
+        });
     });
 
     function dumpEvent(node, session, fields, eventFields, _callback) {


### PR DESCRIPTION
A slow OPC UA server can make the BrowseName read in getBrowseName time out at the secure channel layer. Because __dumpEvent is invoked fire-and-forget from the event async.queue, the rejection surfaced as an unhandled promise rejection and took down the whole Node-RED process.

Guard the read and catch at the queue worker so a transient timeout is logged and skipped instead of fatal.

Fixes #888