### PR TITLE
Preserve OPC UA client reconnection listeners

### DIFF
--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -518,7 +518,6 @@ module.exports = function (RED) {
       */
       verbose_log(chalk.yellow("Exact endpointUrl: ") + chalk.cyan(opcuaEndpoint?.endpoint) + chalk.yellow(" hostname: ") + chalk.cyan(os.hostname()));
       try {
-          node.client = opcua.OPCUAClient.create(options);
           node.client.clientCertificateManager = connectionOption.clientCertificateManager;
           await node.client.clientCertificateManager.initialize();
       }

--- a/test/opcuaClientReconnect.test.js
+++ b/test/opcuaClientReconnect.test.js
@@ -1,0 +1,126 @@
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+const Module = require("node:module");
+const test = require("node:test");
+
+test("the connected OPC UA client retains its reconnection listeners", async () => {
+  const clients = [];
+  const certificateManager = {
+    async initialize() {},
+    trustedFolder: "trusted",
+    rejectedFolder: "rejected",
+    crlFolder: "crl",
+    issuersCertFolder: "issuers",
+    issuersCrlFolder: "issuers-crl"
+  };
+
+  class MockClient extends EventEmitter {
+    constructor() {
+      super();
+      this.clientCertificateManager = certificateManager;
+    }
+
+    async connect() {
+      this.connected = true;
+    }
+
+    async createSession() {
+      return { sessionId: "active" };
+    }
+  }
+
+  const opcua = {
+    AttributeIds: {},
+    DataType: { Null: 0, NodeId: 17 },
+    MessageSecurityMode: { None: 1 },
+    OPCUAClient: {
+      create() {
+        const client = new MockClient();
+        clients.push(client);
+        return client;
+      }
+    },
+    SecurityPolicy: { None: "None" },
+    TimestampsToReturn: {},
+    UserTokenType: { Anonymous: 0, Certificate: 2, UserName: 1 }
+  };
+
+  const identity = (value) => value;
+  const chalk = new Proxy(identity, { get: () => identity });
+  const basics = {
+    calc_milliseconds_by_time_and_unit: () => 300000,
+    get_node_status: (status) => ({ fill: "green", shape: "dot", status })
+  };
+  const stubs = {
+    "async": { queue: function () { return { push() {} }; } },
+    "chalk": chalk,
+    "flatted": { stringify: JSON.stringify },
+    "lodash.clonedeep": (value) => value,
+    "node-opcua": opcua,
+    "node-opcua-client-crawler": { NodeCrawler: class {} },
+    "node-opcua-crypto": {},
+    "node-opcua-file-transfer": {},
+    "./opcua-basics": basics,
+    "./utils": { createClientCertificateManager: () => certificateManager }
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function (request, parent, isMain) {
+    if (Object.hasOwn(stubs, request)) {
+      return stubs[request];
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  let ClientNode;
+  try {
+    const registerClientNode = require("../opcua/102-opcuaclient");
+    registerClientNode({
+      nodes: {
+        createNode(node) {
+          Object.assign(node, {
+            debug() {},
+            error() {},
+            on() {},
+            send() {},
+            status() {},
+            warn() {}
+          });
+        },
+        getNode() {
+          return {
+            endpoint: "opc.tcp://localhost:4840",
+            login: false,
+            none: true,
+            securityMode: "None",
+            securityPolicy: "None",
+            usercert: false
+          };
+        },
+        registerType(name, constructor) {
+          if (name === "OpcUa-Client") ClientNode = constructor;
+        }
+      },
+      settings: { verbose: false }
+    });
+  } finally {
+    Module._load = originalLoad;
+  }
+
+  const node = new ClientNode({
+    action: "read",
+    endpoint: "endpoint",
+    keepsessionalive: false,
+    name: "client",
+    time: 1,
+    timeUnit: "s"
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(clients.length, 1, "connect must reuse the client that owns reconnection listeners");
+  assert.strictEqual(node.client, clients[0]);
+  assert.equal(node.client.listenerCount("backoff"), 1);
+  assert.equal(node.client.listenerCount("start_reconnection"), 1);
+  assert.equal(node.client.listenerCount("connection_reestablished"), 1);
+});


### PR DESCRIPTION
## Summary
- reuse the OPC UA client created with reconnection event listeners
- add a focused test verifying the connected client retains those listeners

## Testing
- `OPENSSL_CONF=/dev/null node --test test/opcuaClientReconnect.test.js`
- syntax checks for the implementation and test files

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

<!-- northset-receipt:M-1039:start -->
### Verification

[Northset proof-of-pass receipt M-1039](https://northset-oss.github.io/verification-pilot/receipts/M-1039/)  
Contributor self-run; not maintainer verification.
<!-- northset-receipt:M-1039:end -->
