### PR TITLE
Fix #801: Prevent Node-RED crash when msg.topic is not a string

### DIFF
--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -728,6 +728,10 @@ module.exports = function (RED) {
         verbose_warn("can't work without OPC UA NodeId - msg.topic empty");
         node.send([null, { error: "can't work without OPC UA NodeId", endpoint: `${opcuaEndpoint?.endpoint}`, status: currentStatus }, null]);
         return;
+      } else if (typeof msg.topic !== 'string') {
+        verbose_warn("can't work without OPC UA NodeId - msg.topic must be a string");
+        node.send([null, { error: "can't work without OPC UA NodeId as a string", endpoint: `${opcuaEndpoint?.endpoint}`, status: currentStatus }, null]);
+        return;
       }
 
       verbose_log(chalk.yellow("Action on input: ") + chalk.cyan(node.action) +


### PR DESCRIPTION
### Description
This PR fixes issue #801, where passing an object in `msg.topic` to opcuaclient causes Node-RED to crash completely due to an unhandled `TypeError`.

### Changes made
* Added a `typeof` validation inside `processInputMsg` to ensure `msg.topic` is strictly a string before proceeding, preventing the crash.
* If the validation fails, the node logs a warning and outputs a controlled error message to the catch node.

Fixes #801