### PR TITLE
Update 102-opcuaclient.js

### DIFF
--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -94,7 +94,7 @@ module.exports = function (RED) {
     if (node.applicationName) connectionOption.applicationName = node.applicationName;
     if (node.applicationUri) connectionOption.applicationUri = node.applicationUri;
     // Moved needed options to client create
-    connectionOption.requestedSessionTimeout = opcuaBasics.calc_milliseconds_by_time_and_unit(300, "s");
+    connectionOption.requestedSessionTimeout = 10000; // 10s for faster disconnect detection (was 300s)
     // DO NOT USE must be NodeOPCUA-Client !! connectionOption.applicationName = node.name; // Application name
     connectionOption.clientName = node.name; // This is used for the session names
     connectionOption.endpointMustExist = false;
@@ -294,9 +294,21 @@ module.exports = function (RED) {
       // node.error("reconnect", msg);
       verbose_log(chalk.red("reconnect")) //  + chalk.cyan(stringify(msg))); // msg is TOO big to show
       set_node_status2_to("reconnect", "attempt #" + attempt + " retry in " + delay / 1000.0 + " sec");
+      // Send reconnect status on third output (error)
+      let endpoint = "";
+      if (opcuaEndpoint?.endpoint) {
+        endpoint = opcuaEndpoint.endpoint;
+      }
+      node.send([null, null, { error: "reconnecting", message: "attempt #" + attempt + " retry in " + delay / 1000.0 + " sec", endpoint: endpoint, status: "reconnect" }]);
     };
     const reconnection = function () {
       set_node_status2_to("reconnect", "starting...");
+      // Send reconnect status on third output (error)
+      let endpoint = "";
+      if (opcuaEndpoint?.endpoint) {
+        endpoint = opcuaEndpoint.endpoint;
+      }
+      node.send([null, null, { error: "reconnecting", message: "starting...", endpoint: endpoint, status: "reconnect" }]);
     };
 
     function create_opcua_client(callback) {
@@ -310,7 +322,7 @@ module.exports = function (RED) {
           clientCertificateManager: connectionOption.clientCertificateManager,
           clientName: node.name, // Fix for #664 sessionName
           keepSessionAlive: node.keepsessionalive,
-          requestedSessionTimeout: 60000 * 5, // 5min, default 1min
+          requestedSessionTimeout: 10000, // 10s for faster disconnect detection (was 5min)
           automaticallyAcceptUnknownCertificate: true,
           // transportSettings: transportSettings // Some 
           applicationName: connectionOption.applicationName,
@@ -594,6 +606,13 @@ module.exports = function (RED) {
           return;
         }
         node.session = session;
+        session.on("keepalive_failure", function () {
+          verbose_log(chalk.red("Session keepalive failed"));
+          set_node_status2_to("reconnect", "session keepalive failed");
+          let endpoint = "";
+          if (opcuaEndpoint?.endpoint) endpoint = opcuaEndpoint.endpoint;
+          node.send([null, null, { error: "reconnecting", message: "session keepalive failed", endpoint, status: "reconnect" }]);
+        });
         set_node_status_to("session active");
         for (let i in cmdQueue) {
           processInputMsg(cmdQueue[i]);
@@ -622,6 +641,7 @@ module.exports = function (RED) {
       verbose_log("Publishing interval " + stringify(parameters));
       newSubscription = opcua.ClientSubscription.create(node.session, parameters);
       verbose_log("Subscription " + newSubscription.toString());
+
       newSubscription.on("initialized", function () {
         verbose_log("Subscription initialized");
         set_node_status_to("initialized");


### PR DESCRIPTION
# Pull Request: Improve OPC UA reconnect detection

## Problem

When an OPC UA Client node loses connection to the server (e.g., cable pull, PLC power off),
the node stays green ("active subscribed") indefinitely. The `node-opcua` library handles
reconnection internally, but the Node-RED node does not show any visual feedback to the user.

**Symptoms:**
- Node stays green "active subscribed" after connection loss
- No status change visible on the node
- No error output on the third output

## Changes
### File: `opcua/102-opcuaclient.js`

#### Change 1: Listen to session `keepalive_failure` event

The `node-opcua` library has a built-in `ClientSessionKeepAliveManager` that periodically
pings the server. When the server does not respond, it emits `keepalive_failure` on the
session. We listen to this event to update the node status immediately.

```diff
  node.session = session;
+ session.on("keepalive_failure", function () {
+   verbose_log(chalk.red("Session keepalive failed"));
+   set_node_status2_to("reconnect", "session keepalive failed");
+   let endpoint = "";
+   if (opcuaEndpoint?.endpoint) endpoint = opcuaEndpoint.endpoint;
+   node.send([null, null, {
+     error: "reconnecting",
+     message: "session keepalive failed",
+     endpoint,
+     status: "reconnect"
+   }]);
+ });
  set_node_status_to("session active");
```

#### Change 2: Reduce `requestedSessionTimeout` from 5 minutes to 10 seconds

The keepalive check interval is derived from the session timeout:
`checkInterval = min(session.timeout * 2/3, 20000)`. With 5 minutes, the check
interval is capped at 20s. With 10s, it becomes ~6.6s, giving ~10s total
detection time instead of ~30-45s.

```diff
- connectionOption.requestedSessionTimeout = 300000; // 5min
+ connectionOption.requestedSessionTimeout = 10000;  // 10s

- requestedSessionTimeout: 60000 * 5, // 5min
+ requestedSessionTimeout: 10000,      // 10s
```

#### Change 3: Send reconnect status on third output from `backoff`/`reconnection` handlers

```diff
  node.send([null, null, { error: "reconnecting",
+     message: "attempt #" + attempt + " retry in " + delay / 1000.0 + " sec",
+     endpoint: endpoint, status: "reconnect" }]); });
```

## Expected Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Connection lost (cable pull, PLC off) | Green forever | 🟡 Yellow after ~10s |
| Connection restored | Green (silent) | 🟢 Green with "re-established" |
| Values change rarely (1x/day) | ✅ Works | ✅ Works (keepalive, not data) |

## Timing

- **Disconnect detection:** ~10 seconds (with `requestedSessionTimeout: 10000`)
- **Reconnect after cable re-plug:** ~5-10 seconds




